### PR TITLE
🔨 fix: link to Sourcify's new APIv2 verifier UI

### DIFF
--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -232,7 +232,7 @@ export default function AnalyzeWizardButton({
           <>
             {`Contract at ${data.address} on chain id ${data.chainId} not verified on Sourcify. Please verify your contract using the `}
             <a
-              href="https://sourcify.dev/#/verifier"
+              href="https://verify.sourcify.dev/"
               target="_blank"
               rel="noopener noreferrer"
               className="text-green-500 underline"


### PR DESCRIPTION
## Summary
- Updates the "Sourcify Verifier" link shown in the Analyze wizard's 404 error to point at Sourcify's new APIv2 verification UI (`https://verify.sourcify.dev/`) instead of the legacy `https://sourcify.dev/#/verifier`.

Closes #70.