### PR TITLE
💅 style: confirm copy in share button tooltip

### DIFF
--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -232,7 +232,7 @@ export default function AnalyzeWizardButton({
           <>
             {`Contract at ${data.address} on chain id ${data.chainId} not verified on Sourcify. Please verify your contract using the `}
             <a
-              href="https://sourcify.dev/#/verifier"
+              href="https://verify.sourcify.dev/"
               target="_blank"
               rel="noopener noreferrer"
               className="text-green-500 underline"

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -56,7 +56,8 @@ export default function StorageVisualizer({
 
   // Share button "Copied!" confirmation (forces tooltip open for 2s after copy)
   const [copied, setCopied] = useState(false);
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const [shareTooltipOpen, setShareTooltipOpen] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   // Close Visualizer
   function handleClose() {
@@ -291,7 +292,7 @@ export default function StorageVisualizer({
                 </TooltipContent>
               </Tooltip>
 
-              <Tooltip open={copied || undefined}>
+              <Tooltip open={copied || shareTooltipOpen} onOpenChange={setShareTooltipOpen}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="ghost"
@@ -301,7 +302,7 @@ export default function StorageVisualizer({
                         await navigator.clipboard.writeText(
                           `https://evm-storage.codes/?address=${address}&chainId=${chainId}`
                         );
-                        clearTimeout(copyTimeoutRef.current);
+                        if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
                         setCopied(true);
                         copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
                       } catch { /* clipboard unavailable */ }

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -54,6 +54,9 @@ export default function StorageVisualizer({
   // Parent dialog controlled state
   const [isAddContractDialogOpen, setAddContractDialogOpen] = useState(false);
 
+  // Share button "Copied!" confirmation (forces tooltip open for 2s after copy)
+  const [copied, setCopied] = useState(false);
+
   // Close Visualizer
   function handleClose() {
     setStorageLayouts((prevLayouts) => {
@@ -287,23 +290,25 @@ export default function StorageVisualizer({
                 </TooltipContent>
               </Tooltip>
 
-              <Tooltip>
+              <Tooltip open={copied || undefined}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="ghost"
                     size="icon"
-                    onClick={() =>
-                      navigator.clipboard.writeText(
+                    onClick={async () => {
+                      await navigator.clipboard.writeText(
                         `https://evm-storage.codes/?address=${address}&chainId=${chainId}`
-                      )
-                    }
+                      );
+                      setCopied(true);
+                      setTimeout(() => setCopied(false), 2000);
+                    }}
                     className="h-6 w-6 text-green-500 hover:bg-green-900/30 hover:text-green-500 hover:rounded"
                   >
                     <Share className="h-3 w-3" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
-                  Share
+                  {copied ? "Copied!" : "Share"}
                 </TooltipContent>
               </Tooltip>
             </>

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useRef, useState } from "react";
 import { Code2, Code, Share, X, Cross, TriangleAlert } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -56,6 +56,7 @@ export default function StorageVisualizer({
 
   // Share button "Copied!" confirmation (forces tooltip open for 2s after copy)
   const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   // Close Visualizer
   function handleClose() {
@@ -296,11 +297,14 @@ export default function StorageVisualizer({
                     variant="ghost"
                     size="icon"
                     onClick={async () => {
-                      await navigator.clipboard.writeText(
-                        `https://evm-storage.codes/?address=${address}&chainId=${chainId}`
-                      );
-                      setCopied(true);
-                      setTimeout(() => setCopied(false), 2000);
+                      try {
+                        await navigator.clipboard.writeText(
+                          `https://evm-storage.codes/?address=${address}&chainId=${chainId}`
+                        );
+                        clearTimeout(copyTimeoutRef.current);
+                        setCopied(true);
+                        copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+                      } catch { /* clipboard unavailable */ }
                     }}
                     className="h-6 w-6 text-green-500 hover:bg-green-900/30 hover:text-green-500 hover:rounded"
                   >


### PR DESCRIPTION
## Summary
- Share button now shows a 2 s "Copied!" confirmation in the existing Radix tooltip after the URL is copied to the clipboard, so users get visible feedback on the action.

Closes #57.

<img width="235" height="175" alt="CleanShot 2026-04-14 at 12 54 33@2x" src="https://github.com/user-attachments/assets/b19c8109-dfd0-49c6-bc60-20eeaed26145" />
