### PR TITLE
feat: add button to copy the storage layout as JSON to fit as LLM context

### DIFF
--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { Code2, Code, Share, X, Cross, TriangleAlert, Braces } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -27,8 +27,9 @@ import AnalyzeWizardButton from "@/components/AnalyzeWizardButton";
 import ComparisonWizardButton from "@/components/ComparisonWizardButton";
 import ColorHash from "color-hash";
 import { normalizeUint256Literal } from "@/lib/integer-literals";
-import { erc7201 } from "@/lib/erc7201";
+import { deriveNamespaceBaseSlot } from "@/lib/erc7201";
 import { buildExport } from "@/lib/storage-layout-export";
+import { useCopyFeedback } from "@/hooks/use-copy-feedback";
 import {
   ROOT_LAYOUT_TAB,
   MAX_CONTIGUOUS_ITEM_SLOT_ROWS,
@@ -81,6 +82,181 @@ function unwrapStructItems(
   return result;
 }
 
+// Interface for ItemWrapper to add additional visualization properties
+interface ItemWrapper {
+  item: StorageItem;
+  color: string;
+  width: number;
+  offset: number;
+}
+
+// A single displayed row. Usually one row is one slot (label is that slot
+// number), but an item spanning more than MAX_CONTIGUOUS_ITEM_SLOT_ROWS
+// slots (e.g. a large __gap array) is collapsed into one row covering the
+// whole range instead of one row per slot it occupies.
+interface SlotRow {
+  items: ItemWrapper[];
+  label: string;
+}
+
+interface StorageLayoutWrapper {
+  slots: SlotRow[];
+  name: string;
+  baseSlot: string | undefined;
+}
+
+// Function to analyze the storage layout and build the wrapper object ot be consumed by the visualizer
+function getStorageLayoutWrapper(
+  storageItems: StorageItem[],
+  storageLayout: StorageLayout,
+  name: string,
+  baseSlot: string | undefined,
+  isNamespace: boolean
+): StorageLayoutWrapper {
+  // Unwrap struct fields so they display individually instead of as one
+  // opaque blob spanning the struct's full size.
+  storageItems = unwrapStructItems(storageItems, storageLayout.types);
+
+  // Normalize baseSlot if is custom
+  if (!isNamespace && baseSlot && baseSlot !== SLOT_ZERO) {
+    const storageItemsNormalized = JSON.parse(JSON.stringify(storageItems));
+    for (let i = 0; i < storageItemsNormalized.length; i++) {
+      storageItemsNormalized[i].slot = (
+        BigInt(normalizeUint256Literal(storageItemsNormalized[i].slot)) -
+        BigInt(baseSlot)
+      ).toString();
+    }
+    storageItems = storageItemsNormalized;
+  }
+
+  // Build astIdToColor object
+  const colorHash = new ColorHash();
+  const idToColor: { [key: string]: string } = {};
+  storageItems.forEach((item) => {
+    idToColor[`${item.contract}:${item.label}`] = colorHash.hex(item.label);
+  });
+
+  let maxSlot = 0;
+  const slots: Array<SlotRow> = [];
+  if (storageItems.length > 0) {
+    // Set maxSlot
+    maxSlot = Number(
+      storageItems
+        .map((storageItem) => storageItem.slot)
+        .reduce((previousValue, currentValue) =>
+          Number(previousValue) >= Number(currentValue)
+            ? previousValue
+            : currentValue
+        )
+    );
+    // Extend max Slot if there is an overflow in the "last" slot
+    const lastSlotTypeNumberOfBytes = Number(
+      storageLayout?.types[storageItems.slice(-1)[0].type].numberOfBytes
+    );
+    if (lastSlotTypeNumberOfBytes > 32) {
+      maxSlot += Math.ceil(lastSlotTypeNumberOfBytes / 32) - 1;
+    }
+
+    // Build slots array. Group items by slot up front: a per-slot filter
+    // over all items would make this loop quadratic on large layouts.
+    const itemsBySlot = new Map<number, StorageItem[]>();
+    for (const item of storageItems) {
+      const slot = Number(item.slot);
+      const group = itemsBySlot.get(slot);
+      if (group) {
+        group.push(item);
+      } else {
+        itemsBySlot.set(slot, [item]);
+      }
+    }
+
+    let overflowBytes = 0;
+    for (let i = 0; i <= maxSlot; i++) {
+      // copy: the overflow handling below unshifts into this array
+      const slotItems = [...(itemsBySlot.get(i) ?? [])];
+
+      // An item spanning more slots than MAX_CONTIGUOUS_ITEM_SLOT_ROWS
+      // (e.g. a large __gap array) is collapsed into a single row instead
+      // of one row per slot: rendering thousands of rows/tooltips makes
+      // the page unresponsive for no visual benefit, since every one of
+      // those rows would look identical anyway.
+      if (overflowBytes === 0 && slotItems.length === 1) {
+        const itemNumberOfBytes = Number(
+          storageLayout?.types[slotItems[0].type].numberOfBytes
+        );
+        const itemSlotSpan = Math.ceil(itemNumberOfBytes / 32);
+        if (itemSlotSpan > MAX_CONTIGUOUS_ITEM_SLOT_ROWS) {
+          const item = slotItems[0];
+          const endSlot = i + itemSlotSpan - 1;
+          slots.push({
+            items: [
+              {
+                item,
+                color: idToColor[`${item.contract}:${item.label}`],
+                width: 100,
+                offset: 0,
+              },
+            ],
+            label: `${i}–${endSlot}`,
+          });
+          i = endSlot;
+          continue;
+        }
+      }
+
+      // if previous slot is overflown
+      if (overflowBytes > 0) {
+        slotItems?.unshift(slots[slots.length - 1].items.slice(-1)[0].item);
+      }
+      // compute bytes used by storage objects in the slot it can overflow
+      let bytesUsed = overflowBytes;
+      slotItems?.forEach(
+        (item) =>
+          (bytesUsed += Number(storageLayout?.types[item.type].numberOfBytes))
+      );
+      // Wrap slot Items
+      const slotItemsWrapped: ItemWrapper[] = slotItems
+        ? slotItems?.map((item, index) => {
+            let width: number = Number(
+              storageLayout?.types[item.type].numberOfBytes
+            );
+            if (index === 0 && overflowBytes > 0) {
+              if (overflowBytes >= 32) {
+                width = 32;
+              } else {
+                width = overflowBytes;
+              }
+            }
+            if (width > 32) {
+              width = 32;
+            }
+            const wrappedItem: ItemWrapper = {
+              item: item,
+              color: idToColor[`${item.contract}:${item.label}`],
+              width: Number(width) * 3.125, // 100%/32Bytes = 3.125
+              offset: Number(item.offset) * 3.125, // 100%/32Bytes = 3.125
+            };
+            return wrappedItem;
+          })
+        : [];
+      // Set next overflow value
+      if (overflowBytes >= 32) {
+        overflowBytes -= 32;
+      } else if (bytesUsed >= 32) {
+        overflowBytes = bytesUsed - 32;
+      } else {
+        overflowBytes = 0;
+      }
+      slots.push({ items: slotItemsWrapped, label: String(i) });
+    }
+  }
+  return {
+    slots: slots,
+    name: name,
+    baseSlot: baseSlot,
+  };
+}
+
 export interface StorageVisualizerProps {
   contractName: string;
   id: number;
@@ -106,54 +282,42 @@ export default function StorageVisualizer({
   // Parent dialog controlled state
   const [isAddContractDialogOpen, setAddContractDialogOpen] = useState(false);
 
-  // Share button "Copied!" confirmation (forces tooltip open for 2s after copy)
-  const [copied, setCopied] = useState(false);
-  const [shareTooltipOpen, setShareTooltipOpen] = useState(false);
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+  // "Copied!"/"Copy failed" tooltip feedback for the share and copy-JSON buttons
+  const shareCopy = useCopyFeedback();
+  const layoutCopy = useCopyFeedback();
 
-  // Copy-JSON button: controlled Tabs + parallel copy/tooltip/popover state
-  const [activeTab, setActiveTab] = useState<string>(ROOT_LAYOUT_TAB);
-  const [layoutCopied, setLayoutCopied] = useState(false);
-  const [layoutTooltipOpen, setLayoutTooltipOpen] = useState(false);
+  // Copy-JSON popover + controlled Tabs
   const [layoutPopoverOpen, setLayoutPopoverOpen] = useState(false);
-  const layoutCopyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const [selectedTab, setSelectedTab] = useState<string>(ROOT_LAYOUT_TAB);
+  // App keys visualizers by index, so on close/insert this instance can be
+  // adopted by a different contract whose layout lacks the remembered
+  // namespace tab — fall back to the root tab instead of rendering an
+  // unmatched Tabs value and exporting a nonexistent slice.
+  const activeTab =
+    selectedTab === ROOT_LAYOUT_TAB || storageLayout.namespaces?.[selectedTab]
+      ? selectedTab
+      : ROOT_LAYOUT_TAB;
 
-  useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-      if (layoutCopyTimeoutRef.current) clearTimeout(layoutCopyTimeoutRef.current);
-    };
-  }, []);
-
-  async function handleCopyJson(mode: "full" | "tab" | "all") {
-    const text =
-      mode === "all"
-        ? buildExport({ mode: "all", layouts: allLayouts })
-        : buildExport({
-            mode,
-            contractName,
-            chainId,
-            address,
-            storageLayout,
-            activeTab,
-          });
-
-    // Flip to "Copied!" before closing the popover so the tooltip's controlled
-    // `open` prop stays true across the popover→tooltip handoff (otherwise
-    // there's a microtask gap where both flags are false and the tooltip
-    // closes without re-opening).
-    if (layoutCopyTimeoutRef.current) clearTimeout(layoutCopyTimeoutRef.current);
-    setLayoutCopied(true);
+  function handleCopyJson(mode: "full" | "tab" | "all") {
+    // Optimistic feedback: the tooltip must already read "Copied!" when the
+    // popover closes (see useCopyFeedback); an export or clipboard failure
+    // downgrades it to "Copy failed".
+    void layoutCopy.copy(
+      () =>
+        mode === "all"
+          ? buildExport({ mode: "all", layouts: allLayouts })
+          : buildExport({
+              mode,
+              contractName,
+              chainId,
+              address,
+              storageLayout,
+              namespace:
+                activeTab === ROOT_LAYOUT_TAB ? undefined : activeTab,
+            }),
+      { optimistic: true }
+    );
     setLayoutPopoverOpen(false);
-    layoutCopyTimeoutRef.current = setTimeout(() => setLayoutCopied(false), 3000);
-
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch {
-      // Clipboard unavailable — undo the optimistic "Copied!" state.
-      if (layoutCopyTimeoutRef.current) clearTimeout(layoutCopyTimeoutRef.current);
-      setLayoutCopied(false);
-    }
   }
 
   // Close Visualizer
@@ -196,206 +360,41 @@ export default function StorageVisualizer({
     }));
   }
 
-  // Interface for ItemWrapper to add additional visualization properties
-  interface ItemWrapper {
-    item: StorageItem;
-    color: string;
-    width: number;
-    offset: number;
-  }
+  // Build the per-tab wrapper array once per layout: controlled Tabs and
+  // tooltip state make every click/hover re-render this component, and the
+  // wrapper computation (struct unwrapping, per-slot scans) is too heavy to
+  // redo each time.
+  const storageLayouts = useMemo(() => {
+    // normalizeUint256Literal returns the zero slot for an absent literal
+    const baseSlotNormalized = normalizeUint256Literal(storageLayout.baseSlot);
 
-  // A single displayed row. Usually one row is one slot (label is that slot
-  // number), but an item spanning more than MAX_CONTIGUOUS_ITEM_SLOT_ROWS
-  // slots (e.g. a large __gap array) is collapsed into one row covering the
-  // whole range instead of one row per slot it occupies.
-  interface SlotRow {
-    items: ItemWrapper[];
-    label: string;
-  }
+    // Root layout
+    const wrappers: StorageLayoutWrapper[] = [
+      getStorageLayoutWrapper(
+        storageLayout.storage,
+        storageLayout,
+        ROOT_LAYOUT_TAB,
+        baseSlotNormalized,
+        false
+      ),
+    ];
 
-  interface StorageLayoutWrapper {
-    slots: SlotRow[];
-    name: string;
-    baseSlot: string;
-  }
-
-  // Function to analyze the storage layout and build the wrapper object ot be consumed by the visualizer
-  function getStorageLayoutWrapper(
-    storageItems: StorageItem[],
-    storageLayout: StorageLayout,
-    name: string = "",
-    baseSlot: string,
-    isNamespace: boolean = false
-  ): StorageLayoutWrapper {
-    // Unwrap struct fields so they display individually instead of as one
-    // opaque blob spanning the struct's full size.
-    storageItems = unwrapStructItems(storageItems, storageLayout.types);
-
-    // Normalize baseSlot if is custom
-    if (!isNamespace && baseSlot !== SLOT_ZERO) {
-      const storageItemsNormalized = JSON.parse(JSON.stringify(storageItems));
-      for (let i = 0; i < storageItemsNormalized.length; i++) {
-        storageItemsNormalized[i].slot = (
-          BigInt(normalizeUint256Literal(storageItemsNormalized[i].slot)) -
-          BigInt(baseSlot)
-        ).toString();
-      }
-      storageItems = storageItemsNormalized;
-    }
-
-    // Build astIdToColor object
-    const colorHash = new ColorHash();
-    const idToColor: { [key: string]: string } = {};
-    storageItems.forEach((item) => {
-      idToColor[`${item.contract}:${item.label}`] = colorHash.hex(item.label);
-    });
-
-    let maxSlot = 0;
-    const slots: Array<SlotRow> = [];
-    if (storageItems.length > 0) {
-      // Set maxSlot
-      maxSlot = Number(
-        storageItems
-          .map((storageItem) => storageItem.slot)
-          .reduce((previousValue, currentValue) =>
-            Number(previousValue) >= Number(currentValue)
-              ? previousValue
-              : currentValue
-          )
-      );
-      // Extend max Slot if there is an overflow in the "last" slot
-      const lastSlotTypeNumberOfBytes = Number(
-        storageLayout?.types[storageItems.slice(-1)[0].type].numberOfBytes
-      );
-      if (lastSlotTypeNumberOfBytes > 32) {
-        maxSlot += Math.ceil(lastSlotTypeNumberOfBytes / 32) - 1;
-      }
-
-      // Build slots array
-      let overflowBytes = 0;
-      for (let i = 0; i <= maxSlot; i++) {
-        const slotItems = storageItems.filter(
-          (item) => Number(item.slot) === i
-        );
-
-        // An item spanning more slots than MAX_CONTIGUOUS_ITEM_SLOT_ROWS
-        // (e.g. a large __gap array) is collapsed into a single row instead
-        // of one row per slot: rendering thousands of rows/tooltips makes
-        // the page unresponsive for no visual benefit, since every one of
-        // those rows would look identical anyway.
-        if (overflowBytes === 0 && slotItems.length === 1) {
-          const itemNumberOfBytes = Number(
-            storageLayout?.types[slotItems[0].type].numberOfBytes
-          );
-          const itemSlotSpan = Math.ceil(itemNumberOfBytes / 32);
-          if (itemSlotSpan > MAX_CONTIGUOUS_ITEM_SLOT_ROWS) {
-            const item = slotItems[0];
-            const endSlot = i + itemSlotSpan - 1;
-            slots.push({
-              items: [
-                {
-                  item,
-                  color: idToColor[`${item.contract}:${item.label}`],
-                  width: 100,
-                  offset: 0,
-                },
-              ],
-              label: `${i}–${endSlot}`,
-            });
-            i = endSlot;
-            continue;
-          }
-        }
-
-        // if previous slot is overflown
-        if (overflowBytes > 0) {
-          slotItems?.unshift(slots[slots.length - 1].items.slice(-1)[0].item);
-        }
-        // compute bytes used by storage objects in the slot it can overflow
-        let bytesUsed = overflowBytes;
-        slotItems?.forEach(
-          (item) =>
-            (bytesUsed += Number(storageLayout?.types[item.type].numberOfBytes))
-        );
-        // Wrap slot Items
-        const slotItemsWrapped: ItemWrapper[] = slotItems
-          ? slotItems?.map((item, index) => {
-              let width: number = Number(
-                storageLayout?.types[item.type].numberOfBytes
-              );
-              if (index === 0 && overflowBytes > 0) {
-                if (overflowBytes >= 32) {
-                  width = 32;
-                } else {
-                  width = overflowBytes;
-                }
-              }
-              if (width > 32) {
-                width = 32;
-              }
-              const wrappedItem: ItemWrapper = {
-                item: item,
-                color: idToColor[`${item.contract}:${item.label}`],
-                width: Number(width) * 3.125, // 100%/32Bytes = 3.125
-                offset: Number(item.offset) * 3.125, // 100%/32Bytes = 3.125
-              };
-              return wrappedItem;
-            })
-          : [];
-        // Set next overflow value
-        if (overflowBytes >= 32) {
-          overflowBytes -= 32;
-        } else if (bytesUsed >= 32) {
-          overflowBytes = bytesUsed - 32;
-        } else {
-          overflowBytes = 0;
-        }
-        slots.push({ items: slotItemsWrapped, label: String(i) });
-      }
-    }
-    return {
-      slots: slots,
-      name: name,
-      baseSlot: baseSlot,
-    };
-  }
-
-  // Get root layout base slot
-  let baseSlotNormalized = SLOT_ZERO;
-
-  // Parse and set baseSlot if it is present and defined
-  if ("baseSlot" in storageLayout && storageLayout.baseSlot) {
-    baseSlotNormalized = normalizeUint256Literal(storageLayout.baseSlot);
-  }
-
-  // Build storage layouts array for the visualizer
-  const storageLayouts: StorageLayoutWrapper[] = [];
-
-  // Root layout
-  storageLayouts.push(
-    getStorageLayoutWrapper(
-      storageLayout.storage,
-      storageLayout,
-      ROOT_LAYOUT_TAB,
-      baseSlotNormalized,
-      false
-    )
-  );
-
-  // ERC-7201 namespaces
-  if (storageLayout.namespaces !== undefined) {
-    Object.keys(storageLayout.namespaces).forEach((namespaceName) => {
-      storageLayouts.push(
+    // ERC-7201 namespaces
+    for (const [namespaceName, items] of Object.entries(
+      storageLayout.namespaces ?? {}
+    )) {
+      wrappers.push(
         getStorageLayoutWrapper(
-          storageLayout.namespaces![namespaceName],
+          items,
           storageLayout,
           namespaceName,
-          erc7201(namespaceName.split(":")[1]),
+          deriveNamespaceBaseSlot(namespaceName),
           true
         )
       );
-    });
-  }
+    }
+    return wrappers;
+  }, [storageLayout]);
 
   return (
     <Card className="bg-black border-green-500 md:mb-4 overflow-hidden relative py-0 gap-0 h-full w-full transition-all duration-500 ease-in-out">
@@ -436,20 +435,16 @@ export default function StorageVisualizer({
                 </TooltipContent>
               </Tooltip>
 
-              <Tooltip open={copied || shareTooltipOpen} onOpenChange={setShareTooltipOpen}>
+              <Tooltip {...shareCopy.tooltipProps}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="ghost"
                     size="icon"
-                    onClick={async () => {
-                      try {
-                        await navigator.clipboard.writeText(
+                    onClick={() => {
+                      void shareCopy.copy(
+                        () =>
                           `${window.location.origin}/?address=${address}&chainId=${chainId}`
-                        );
-                        if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-                        setCopied(true);
-                        copyTimeoutRef.current = setTimeout(() => setCopied(false), 3000);
-                      } catch { /* clipboard unavailable */ }
+                      );
                     }}
                     className="h-6 w-6 text-green-500 hover:bg-green-900/30 hover:text-green-500 hover:rounded"
                   >
@@ -457,16 +452,13 @@ export default function StorageVisualizer({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
-                  {copied ? "Copied!" : "Share"}
+                  {shareCopy.label("Share")}
                 </TooltipContent>
               </Tooltip>
             </>
           )}
           <Popover open={layoutPopoverOpen} onOpenChange={setLayoutPopoverOpen}>
-            <Tooltip
-              open={layoutCopied || layoutTooltipOpen}
-              onOpenChange={setLayoutTooltipOpen}
-            >
+            <Tooltip {...layoutCopy.tooltipProps}>
               <TooltipTrigger asChild>
                 <PopoverTrigger asChild>
                   <Button
@@ -479,7 +471,7 @@ export default function StorageVisualizer({
                 </PopoverTrigger>
               </TooltipTrigger>
               <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
-                {layoutCopied ? "Copied!" : "Copy Storage Layout"}
+                {layoutCopy.label("Copy Storage Layout")}
               </TooltipContent>
             </Tooltip>
             <PopoverContent
@@ -584,7 +576,7 @@ export default function StorageVisualizer({
       </div>
 
       {/* Tabs*/}
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+      <Tabs value={activeTab} onValueChange={setSelectedTab} className="w-full">
         <div
           className="border-b border-green-500/30 bg-green-900/10 overflow-x-auto
                   minimal-h-scrollbar-green
@@ -613,9 +605,11 @@ export default function StorageVisualizer({
         {/*Content */}
         {storageLayouts.map((layout, index) => (
           <TabsContent value={layout.name} className="mt-0">
-            <div className="px-4 pb-2 text-green-500 text-[8px] md:text-[11px]">
-              base slot: {layout.baseSlot}
-            </div>
+            {layout.baseSlot !== undefined && (
+              <div className="px-4 pb-2 text-green-500 text-[8px] md:text-[11px]">
+                base slot: {layout.baseSlot}
+              </div>
+            )}
             {layout.slots.length === 0 && (
               <div className="flex items-center justify-center gap-2 px-4 pb-2 my-5 text-green-500">
                 <TriangleAlert className="h-4 w-4" />

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -1,5 +1,5 @@
 import { useContext, useRef, useState } from "react";
-import { Code2, Code, Share, X, Cross, TriangleAlert } from "lucide-react";
+import { Code2, Code, Share, X, Cross, TriangleAlert, Braces } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -8,6 +8,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { StorageLayoutsContext } from "../App";
 import {
   Dialog,
@@ -23,6 +28,7 @@ import ComparisonWizardButton from "@/components/ComparisonWizardButton";
 import ColorHash from "color-hash";
 import { normalizeUint256Literal } from "@/lib/integer-literals";
 import { erc7201 } from "@/lib/erc7201";
+import { buildExport } from "@/lib/storage-layout-export";
 
 import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
 
@@ -49,7 +55,7 @@ export default function StorageVisualizer({
   if (!storageLayoutsContext) {
     throw new Error("StorageLayoutsContext is undefined");
   }
-  const { setStorageLayouts } = storageLayoutsContext;
+  const { storageLayouts: allLayouts, setStorageLayouts } = storageLayoutsContext;
 
   // Parent dialog controlled state
   const [isAddContractDialogOpen, setAddContractDialogOpen] = useState(false);
@@ -58,6 +64,44 @@ export default function StorageVisualizer({
   const [copied, setCopied] = useState(false);
   const [shareTooltipOpen, setShareTooltipOpen] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  // Copy-JSON button: controlled Tabs + parallel copy/tooltip/popover state
+  const [activeTab, setActiveTab] = useState<string>("Root layout");
+  const [layoutCopied, setLayoutCopied] = useState(false);
+  const [layoutTooltipOpen, setLayoutTooltipOpen] = useState(false);
+  const [layoutPopoverOpen, setLayoutPopoverOpen] = useState(false);
+  const layoutCopyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  async function handleCopyJson(mode: "full" | "tab" | "all") {
+    const text =
+      mode === "all"
+        ? buildExport({ mode: "all", layouts: allLayouts })
+        : buildExport({
+            mode,
+            contractName,
+            chainId,
+            address,
+            storageLayout,
+            activeTab,
+          });
+
+    // Flip to "Copied!" before closing the popover so the tooltip's controlled
+    // `open` prop stays true across the popover→tooltip handoff (otherwise
+    // there's a microtask gap where both flags are false and the tooltip
+    // closes without re-opening).
+    if (layoutCopyTimeoutRef.current) clearTimeout(layoutCopyTimeoutRef.current);
+    setLayoutCopied(true);
+    setLayoutPopoverOpen(false);
+    layoutCopyTimeoutRef.current = setTimeout(() => setLayoutCopied(false), 3000);
+
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Clipboard unavailable — undo the optimistic "Copied!" state.
+      if (layoutCopyTimeoutRef.current) clearTimeout(layoutCopyTimeoutRef.current);
+      setLayoutCopied(false);
+    }
+  }
 
   // Close Visualizer
   function handleClose() {
@@ -304,7 +348,7 @@ export default function StorageVisualizer({
                         );
                         if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
                         setCopied(true);
-                        copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+                        copyTimeoutRef.current = setTimeout(() => setCopied(false), 3000);
                       } catch { /* clipboard unavailable */ }
                     }}
                     className="h-6 w-6 text-green-500 hover:bg-green-900/30 hover:text-green-500 hover:rounded"
@@ -318,6 +362,59 @@ export default function StorageVisualizer({
               </Tooltip>
             </>
           )}
+          <Popover open={layoutPopoverOpen} onOpenChange={setLayoutPopoverOpen}>
+            <Tooltip
+              open={layoutCopied || layoutTooltipOpen}
+              onOpenChange={setLayoutTooltipOpen}
+            >
+              <TooltipTrigger asChild>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-green-500 hover:bg-green-900/30 hover:text-green-500 hover:rounded"
+                  >
+                    <Braces className="h-3 w-3" />
+                  </Button>
+                </PopoverTrigger>
+              </TooltipTrigger>
+              <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
+                {layoutCopied ? "Copied!" : "Copy Storage Layout"}
+              </TooltipContent>
+            </Tooltip>
+            <PopoverContent
+              align="end"
+              className="bg-black border-green-500 border text-green-500 p-1 rounded-md shadow-md text-xs w-56"
+            >
+              <div className="flex flex-col">
+                <Button
+                  variant="ghost"
+                  onClick={() => handleCopyJson("full")}
+                  className="w-full justify-start h-8 text-xs text-green-500 hover:bg-green-900/30 hover:text-green-500"
+                >
+                  Copy full layout
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => handleCopyJson("tab")}
+                  className="w-full justify-start h-8 text-xs text-green-500 hover:bg-green-900/30 hover:text-green-500"
+                >
+                  <span className="truncate max-w-[180px]">
+                    Copy current tab ({activeTab})
+                  </span>
+                </Button>
+                {allLayouts.length >= 2 && (
+                  <Button
+                    variant="ghost"
+                    onClick={() => handleCopyJson("all")}
+                    className="w-full justify-start h-8 text-xs text-green-500 hover:bg-green-900/30 hover:text-green-500"
+                  >
+                    Copy all open contracts
+                  </Button>
+                )}
+              </div>
+            </PopoverContent>
+          </Popover>
           <ComparisonWizardButton />
 
           {/* Add Contract Dialog */}
@@ -387,7 +484,7 @@ export default function StorageVisualizer({
       </div>
 
       {/* Tabs*/}
-      <Tabs defaultValue="Root layout" className="w-full">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
         <div
           className="border-b border-green-500/30 bg-green-900/10 overflow-x-auto
                   minimal-h-scrollbar-green

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { Code2, Code, Share, X, Cross, TriangleAlert, Braces } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -29,6 +29,7 @@ import ColorHash from "color-hash";
 import { normalizeUint256Literal } from "@/lib/integer-literals";
 import { erc7201 } from "@/lib/erc7201";
 import { buildExport } from "@/lib/storage-layout-export";
+import { ROOT_LAYOUT_TAB } from "@/lib/constants";
 
 import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
 
@@ -66,11 +67,18 @@ export default function StorageVisualizer({
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   // Copy-JSON button: controlled Tabs + parallel copy/tooltip/popover state
-  const [activeTab, setActiveTab] = useState<string>("Root layout");
+  const [activeTab, setActiveTab] = useState<string>(ROOT_LAYOUT_TAB);
   const [layoutCopied, setLayoutCopied] = useState(false);
   const [layoutTooltipOpen, setLayoutTooltipOpen] = useState(false);
   const [layoutPopoverOpen, setLayoutPopoverOpen] = useState(false);
   const layoutCopyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      if (layoutCopyTimeoutRef.current) clearTimeout(layoutCopyTimeoutRef.current);
+    };
+  }, []);
 
   async function handleCopyJson(mode: "full" | "tab" | "all") {
     const text =
@@ -276,7 +284,7 @@ export default function StorageVisualizer({
     getStorageLayoutWrapper(
       storageLayout.storage,
       storageLayout,
-      "Root layout",
+      ROOT_LAYOUT_TAB,
       baseSlotNormalized,
       false
     )

--- a/src/hooks/use-copy-feedback.ts
+++ b/src/hooks/use-copy-feedback.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from "react";
+
+type CopyStatus = "copied" | "failed" | null;
+
+/**
+ * Transient clipboard-copy feedback for an icon button with a controlled
+ * tooltip. Spread `tooltipProps` onto the Tooltip — it keeps the tooltip
+ * forced open while feedback is showing — and render `label(idle)` as its
+ * content: the idle text normally, "Copied!"/"Copy failed" for `durationMs`
+ * after a copy resolves.
+ *
+ * `copy` resolves the text inside its try/catch, so both text building and
+ * the clipboard write surface as "failed". With `optimistic: true` the
+ * status flips to "copied" before the write — needed when the click also
+ * closes a popover sharing the trigger, so the tooltip's controlled `open`
+ * stays true across the popover→tooltip handoff (otherwise there's a
+ * microtask gap where both flags are false and the tooltip closes without
+ * re-opening); a failure then downgrades the status to "Copy failed".
+ */
+export function useCopyFeedback(durationMs: number = 3000) {
+  const [status, setStatus] = useState<CopyStatus>(null);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  function flash(outcome: "copied" | "failed") {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setStatus(outcome);
+    timeoutRef.current = setTimeout(() => setStatus(null), durationMs);
+  }
+
+  async function copy(
+    getText: () => string,
+    { optimistic = false }: { optimistic?: boolean } = {}
+  ) {
+    if (optimistic) flash("copied");
+    try {
+      await navigator.clipboard.writeText(getText());
+      if (!optimistic) flash("copied");
+    } catch {
+      flash("failed");
+    }
+  }
+
+  return {
+    copy,
+    tooltipProps: {
+      open: status !== null || tooltipOpen,
+      onOpenChange: setTooltipOpen,
+    },
+    label(idle: string) {
+      return status === "copied"
+        ? "Copied!"
+        : status === "failed"
+          ? "Copy failed"
+          : idle;
+    },
+  };
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,3 +13,4 @@ export const EVM_VERSIONS = [
   "constantinople",
 ];
 export const BROTLI_QUALITY = 9;
+export const ROOT_LAYOUT_TAB = "Root layout";

--- a/src/lib/erc7201.ts
+++ b/src/lib/erc7201.ts
@@ -13,3 +13,19 @@ export function erc7201(id: string): `0x${string}` {
   const padded = v2.toString(16).padStart(64, "0");
   return `0x${padded}` as `0x${string}`;
 }
+
+/**
+ * Derives the absolute base slot for a `@custom:storage-location` namespace
+ * key, e.g. "erc7201:example.main". Only the erc7201 formula is supported;
+ * the id portion (which may itself contain colons) is fed to erc7201().
+ * Returns undefined for any other formula prefix so callers can omit the
+ * value instead of deriving a meaningless one.
+ */
+export function deriveNamespaceBaseSlot(
+  namespaceKey: string
+): `0x${string}` | undefined {
+  const prefix = "erc7201:";
+  if (!namespaceKey.startsWith(prefix)) return undefined;
+  const id = namespaceKey.slice(prefix.length);
+  return id.length > 0 ? erc7201(id) : undefined;
+}

--- a/src/lib/storage-layout-export.ts
+++ b/src/lib/storage-layout-export.ts
@@ -1,5 +1,9 @@
 import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
 import { erc7201 } from "@/lib/erc7201";
+import { ROOT_LAYOUT_TAB } from "@/lib/constants";
+
+const EXPORT_SCHEMA_VERSION = "evm-storage.codes/storage-layout-export@1";
+const JSON_INDENT_SPACES = 2;
 
 // Runtime type entries carry untyped solc fields (encoding, key, value, base)
 // that the OZ TypeItem interface doesn't declare. We preserve them verbatim.
@@ -72,6 +76,15 @@ function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
   return out;
 }
 
+// Derives the absolute ERC-7201 base slot for a "erc7201:<id>" namespace key.
+// Returns undefined for non-namespace strings (e.g. custom-encoded namespaces).
+function deriveNamespaceBaseSlot(namespace: string): string | undefined {
+  const prefix = "erc7201:";
+  if (!namespace.startsWith(prefix)) return undefined;
+  const id = namespace.slice(prefix.length).trim();
+  return id.length > 0 ? erc7201(id) : undefined;
+}
+
 function buildWrapper(
   entry: LayoutEntry,
   mode: "full" | "tab",
@@ -85,7 +98,13 @@ function buildWrapper(
     const namespacesRaw = storageLayout.namespaces;
     const namespaces = namespacesRaw
       ? Object.fromEntries(
-          Object.entries(namespacesRaw).map(([k, v]) => [k, slimStorageItems(v)]),
+          Object.entries(namespacesRaw).map(([k, v]) => [
+            k,
+            omitUndefined({
+              baseSlot: deriveNamespaceBaseSlot(k),
+              storage: slimStorageItems(v),
+            }),
+          ]),
         )
       : undefined;
 
@@ -97,6 +116,7 @@ function buildWrapper(
     const types = pickReferencedTypes(allItems, allTypes);
 
     return omitUndefined({
+      schemaVersion: EXPORT_SCHEMA_VERSION,
       contractName,
       chainId,
       address,
@@ -110,24 +130,26 @@ function buildWrapper(
   }
 
   // mode === "tab"
-  const isRoot = activeTab === "Root layout";
-  const rawItems = isRoot
-    ? storageLayout.storage ?? []
-    : storageLayout.namespaces?.[activeTab] ?? [];
+  const isRoot = activeTab === ROOT_LAYOUT_TAB;
+  const namespaceItems = isRoot ? undefined : storageLayout.namespaces?.[activeTab];
+  if (!isRoot && namespaceItems === undefined) {
+    throw new Error(`Unknown storage layout tab: ${activeTab}`);
+  }
+  const rawItems = isRoot ? storageLayout.storage ?? [] : namespaceItems!;
   const items = slimStorageItems(rawItems);
   const types = pickReferencedTypes(rawItems, allTypes);
 
   // For namespace tabs, derive baseSlot from the ERC-7201 id portion.
-  // The namespace name follows the convention "erc7201:<id>".
   let baseSlot: string | undefined = storageLayout.baseSlot;
   let namespace: string | undefined;
   if (!isRoot) {
     namespace = activeTab;
-    const idPart = activeTab.split(":")[1];
-    if (idPart) baseSlot = erc7201(idPart);
+    const derived = deriveNamespaceBaseSlot(activeTab);
+    if (derived) baseSlot = derived;
   }
 
   return omitUndefined({
+    schemaVersion: EXPORT_SCHEMA_VERSION,
     contractName,
     chainId,
     address,
@@ -142,8 +164,14 @@ function buildWrapper(
 
 export function buildExport(opts: SingleOpts | AllOpts): string {
   if (opts.mode === "all") {
-    const contracts = opts.layouts.map((l) => buildWrapper(l, "full", "Root layout"));
-    return JSON.stringify({ contracts }, null, 2);
+    const contracts = opts.layouts.map((l) =>
+      buildWrapper(l, "full", ROOT_LAYOUT_TAB),
+    );
+    return JSON.stringify(
+      { schemaVersion: EXPORT_SCHEMA_VERSION, contracts },
+      null,
+      JSON_INDENT_SPACES,
+    );
   }
 
   const entry: LayoutEntry = {
@@ -153,5 +181,5 @@ export function buildExport(opts: SingleOpts | AllOpts): string {
     storageLayout: opts.storageLayout,
   };
   const wrapper = buildWrapper(entry, opts.mode, opts.activeTab);
-  return JSON.stringify(wrapper, null, 2);
+  return JSON.stringify(wrapper, null, JSON_INDENT_SPACES);
 }

--- a/src/lib/storage-layout-export.ts
+++ b/src/lib/storage-layout-export.ts
@@ -1,0 +1,157 @@
+import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
+import { erc7201 } from "@/lib/erc7201";
+
+// Runtime type entries carry untyped solc fields (encoding, key, value, base)
+// that the OZ TypeItem interface doesn't declare. We preserve them verbatim.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RawTypes = Record<string, Record<string, any>>;
+
+export type LayoutEntry = {
+  contractName: string;
+  chainId: number | undefined;
+  address: string | undefined;
+  storageLayout: StorageLayout;
+};
+
+type SingleOpts = {
+  mode: "full" | "tab";
+  contractName: string;
+  chainId: number | undefined;
+  address: string | undefined;
+  storageLayout: StorageLayout;
+  activeTab: string;
+};
+
+type AllOpts = {
+  mode: "all";
+  layouts: LayoutEntry[];
+};
+
+export function slimStorageItems(items: StorageItem[]) {
+  return items.map((item) => {
+    const copy: Record<string, unknown> = { ...item };
+    delete copy.astId;
+    delete copy.src;
+    return copy;
+  });
+}
+
+export function pickReferencedTypes(
+  items: StorageItem[],
+  allTypes: RawTypes,
+): RawTypes {
+  const out: RawTypes = {};
+  const seen = new Set<string>();
+  const queue: string[] = items.map((i) => i.type);
+
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const t = allTypes[id];
+    if (!t) continue;
+    out[id] = t;
+    if (Array.isArray(t.members)) {
+      for (const m of t.members) {
+        if (m && typeof m.type === "string") queue.push(m.type);
+      }
+    }
+    for (const k of ["underlying", "key", "value", "base"] as const) {
+      const v = t[k];
+      if (typeof v === "string" && allTypes[v]) queue.push(v);
+    }
+  }
+  return out;
+}
+
+function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  const out: Partial<T> = {};
+  for (const k in obj) {
+    if (obj[k] !== undefined) out[k] = obj[k];
+  }
+  return out;
+}
+
+function buildWrapper(
+  entry: LayoutEntry,
+  mode: "full" | "tab",
+  activeTab: string,
+): Record<string, unknown> {
+  const { contractName, chainId, address, storageLayout } = entry;
+  const allTypes = (storageLayout.types ?? {}) as RawTypes;
+
+  if (mode === "full") {
+    const rootItems = slimStorageItems(storageLayout.storage ?? []);
+    const namespacesRaw = storageLayout.namespaces;
+    const namespaces = namespacesRaw
+      ? Object.fromEntries(
+          Object.entries(namespacesRaw).map(([k, v]) => [k, slimStorageItems(v)]),
+        )
+      : undefined;
+
+    // Union all items so the types dict stays minimal but complete.
+    const allItems: StorageItem[] = [
+      ...(storageLayout.storage ?? []),
+      ...Object.values(storageLayout.namespaces ?? {}).flat(),
+    ];
+    const types = pickReferencedTypes(allItems, allTypes);
+
+    return omitUndefined({
+      contractName,
+      chainId,
+      address,
+      solcVersion: storageLayout.solcVersion,
+      layoutVersion: storageLayout.layoutVersion,
+      baseSlot: storageLayout.baseSlot,
+      storage: rootItems,
+      types,
+      namespaces,
+    });
+  }
+
+  // mode === "tab"
+  const isRoot = activeTab === "Root layout";
+  const rawItems = isRoot
+    ? storageLayout.storage ?? []
+    : storageLayout.namespaces?.[activeTab] ?? [];
+  const items = slimStorageItems(rawItems);
+  const types = pickReferencedTypes(rawItems, allTypes);
+
+  // For namespace tabs, derive baseSlot from the ERC-7201 id portion.
+  // The namespace name follows the convention "erc7201:<id>".
+  let baseSlot: string | undefined = storageLayout.baseSlot;
+  let namespace: string | undefined;
+  if (!isRoot) {
+    namespace = activeTab;
+    const idPart = activeTab.split(":")[1];
+    if (idPart) baseSlot = erc7201(idPart);
+  }
+
+  return omitUndefined({
+    contractName,
+    chainId,
+    address,
+    solcVersion: storageLayout.solcVersion,
+    layoutVersion: storageLayout.layoutVersion,
+    namespace,
+    baseSlot,
+    storage: items,
+    types,
+  });
+}
+
+export function buildExport(opts: SingleOpts | AllOpts): string {
+  if (opts.mode === "all") {
+    const contracts = opts.layouts.map((l) => buildWrapper(l, "full", "Root layout"));
+    return JSON.stringify({ contracts }, null, 2);
+  }
+
+  const entry: LayoutEntry = {
+    contractName: opts.contractName,
+    chainId: opts.chainId,
+    address: opts.address,
+    storageLayout: opts.storageLayout,
+  };
+  const wrapper = buildWrapper(entry, opts.mode, opts.activeTab);
+  return JSON.stringify(wrapper, null, 2);
+}

--- a/src/lib/storage-layout-export.ts
+++ b/src/lib/storage-layout-export.ts
@@ -1,6 +1,6 @@
 import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
-import { erc7201 } from "@/lib/erc7201";
-import { ROOT_LAYOUT_TAB } from "@/lib/constants";
+import { deriveNamespaceBaseSlot } from "@/lib/erc7201";
+import { normalizeUint256Literal } from "@/lib/integer-literals";
 
 const EXPORT_SCHEMA_VERSION = "evm-storage.codes/storage-layout-export@1";
 const JSON_INDENT_SPACES = 2;
@@ -17,13 +17,10 @@ export type LayoutEntry = {
   storageLayout: StorageLayout;
 };
 
-type SingleOpts = {
+type SingleOpts = LayoutEntry & {
   mode: "full" | "tab";
-  contractName: string;
-  chainId: number | undefined;
-  address: string | undefined;
-  storageLayout: StorageLayout;
-  activeTab: string;
+  /** Namespace key to export in "tab" mode; undefined means the root slice. */
+  namespace?: string;
 };
 
 type AllOpts = {
@@ -63,57 +60,47 @@ export function pickReferencedTypes(
 ): RawTypes {
   const out: RawTypes = {};
   const seen = new Set<string>();
-  const queue: string[] = items.map((i) => i.type);
+  const queue: string[] = [];
+  // Dedup at enqueue time and walk with a cursor: shift() is O(n) per pop,
+  // and ubiquitous types (t_uint256, ...) would otherwise enter the queue
+  // once per reference.
+  const enqueue = (id: string) => {
+    if (!seen.has(id)) {
+      seen.add(id);
+      queue.push(id);
+    }
+  };
+  for (const item of items) enqueue(item.type);
 
-  while (queue.length > 0) {
-    const id = queue.shift()!;
-    if (seen.has(id)) continue;
-    seen.add(id);
+  for (let head = 0; head < queue.length; head++) {
+    const id = queue[head];
     const t = allTypes[id];
     if (!t) continue;
     out[id] = t;
     if (Array.isArray(t.members)) {
       for (const m of t.members) {
-        if (m && typeof m.type === "string") queue.push(m.type);
+        if (m && typeof m.type === "string") enqueue(m.type);
       }
     }
     for (const k of ["underlying", "key", "value", "base"] as const) {
       const v = t[k];
-      if (typeof v === "string" && allTypes[v]) queue.push(v);
+      if (typeof v === "string" && allTypes[v]) enqueue(v);
     }
   }
   return out;
 }
 
 /**
- * Returns a shallow copy with all `undefined`-valued keys dropped.
- *
- * Keeps optional fields (chainId, address, baseSlot, namespaces)
- * out of the JSON entirely when they have no value, instead of
- * serializing them as explicit nulls.
+ * Normalizes the root layout's custom base slot (Solidity 0.8.29+
+ * `layout at <literal>`) to the padded hex form the UI displays,
+ * or undefined when the layout has none so the field is omitted.
  */
-function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
-  const out: Partial<T> = {};
-  for (const k in obj) {
-    if (obj[k] !== undefined) out[k] = obj[k];
-  }
-  return out;
-}
-
-/**
- * Derives the absolute ERC-7201 base slot for a namespace key.
- *
- * Expects the "erc7201:<id>" convention and computes
- * keccak256(keccak256(id) - 1) & ~0xff over the id portion.
- * Returns undefined for any string that is not so prefixed
- * (for example custom-encoded namespaces), so the caller can
- * omit the field rather than crash.
- */
-function deriveNamespaceBaseSlot(namespace: string): string | undefined {
-  const prefix = "erc7201:";
-  if (!namespace.startsWith(prefix)) return undefined;
-  const id = namespace.slice(prefix.length).trim();
-  return id.length > 0 ? erc7201(id) : undefined;
+function normalizedRootBaseSlot(
+  storageLayout: StorageLayout,
+): string | undefined {
+  return storageLayout.baseSlot
+    ? normalizeUint256Literal(storageLayout.baseSlot)
+    : undefined;
 }
 
 /**
@@ -122,31 +109,34 @@ function deriveNamespaceBaseSlot(namespace: string): string | undefined {
  * In "full" mode it emits the root storage plus every namespace,
  * each namespace tagged with its derived baseSlot, and a single
  * types dictionary covering all of them. In "tab" mode it emits
- * only the active slice (root or one namespace), with the
- * namespace tab carrying its own baseSlot and namespace name.
+ * a single slice: the given namespace, or the root storage when
+ * `namespace` is undefined.
  */
 function buildWrapper(
   entry: LayoutEntry,
   mode: "full" | "tab",
-  activeTab: string,
+  namespace?: string,
 ): Record<string, unknown> {
   const { contractName, chainId, address, storageLayout } = entry;
   const allTypes = (storageLayout.types ?? {}) as RawTypes;
 
   if (mode === "full") {
     const rootItems = slimStorageItems(storageLayout.storage ?? []);
+    // Extraction always defines `namespaces` ({} when the contract has
+    // none), so gate on emptiness, not just presence.
     const namespacesRaw = storageLayout.namespaces;
-    const namespaces = namespacesRaw
-      ? Object.fromEntries(
-          Object.entries(namespacesRaw).map(([k, v]) => [
-            k,
-            omitUndefined({
-              baseSlot: deriveNamespaceBaseSlot(k),
-              storage: slimStorageItems(v),
-            }),
-          ]),
-        )
-      : undefined;
+    const namespaces =
+      namespacesRaw && Object.keys(namespacesRaw).length > 0
+        ? Object.fromEntries(
+            Object.entries(namespacesRaw).map(([k, v]) => [
+              k,
+              {
+                baseSlot: deriveNamespaceBaseSlot(k),
+                storage: slimStorageItems(v),
+              },
+            ]),
+          )
+        : undefined;
 
     // Union all items so the types dict stays minimal but complete.
     const allItems: StorageItem[] = [
@@ -155,40 +145,39 @@ function buildWrapper(
     ];
     const types = pickReferencedTypes(allItems, allTypes);
 
-    return omitUndefined({
+    return {
       schemaVersion: EXPORT_SCHEMA_VERSION,
       contractName,
       chainId,
       address,
       solcVersion: storageLayout.solcVersion,
       layoutVersion: storageLayout.layoutVersion,
-      baseSlot: storageLayout.baseSlot,
+      baseSlot: normalizedRootBaseSlot(storageLayout),
       storage: rootItems,
       types,
       namespaces,
-    });
+    };
   }
 
-  // mode === "tab"
-  const isRoot = activeTab === ROOT_LAYOUT_TAB;
-  const namespaceItems = isRoot ? undefined : storageLayout.namespaces?.[activeTab];
-  if (!isRoot && namespaceItems === undefined) {
-    throw new Error(`Unknown storage layout tab: ${activeTab}`);
+  // mode === "tab": one slice. The root slice carries the layout's own
+  // (custom) base slot; a namespace carries only its ERC-7201-derived one,
+  // omitted when the key uses some other formula — the root base slot never
+  // applies to a namespace.
+  let rawItems: StorageItem[];
+  let baseSlot: string | undefined;
+  if (namespace === undefined) {
+    rawItems = storageLayout.storage ?? [];
+    baseSlot = normalizedRootBaseSlot(storageLayout);
+  } else {
+    const namespaceItems = storageLayout.namespaces?.[namespace];
+    if (namespaceItems === undefined) {
+      throw new Error(`Unknown storage layout namespace: ${namespace}`);
+    }
+    rawItems = namespaceItems;
+    baseSlot = deriveNamespaceBaseSlot(namespace);
   }
-  const rawItems = isRoot ? storageLayout.storage ?? [] : namespaceItems!;
-  const items = slimStorageItems(rawItems);
-  const types = pickReferencedTypes(rawItems, allTypes);
 
-  // For namespace tabs, derive baseSlot from the ERC-7201 id portion.
-  let baseSlot: string | undefined = storageLayout.baseSlot;
-  let namespace: string | undefined;
-  if (!isRoot) {
-    namespace = activeTab;
-    const derived = deriveNamespaceBaseSlot(activeTab);
-    if (derived) baseSlot = derived;
-  }
-
-  return omitUndefined({
+  return {
     schemaVersion: EXPORT_SCHEMA_VERSION,
     contractName,
     chainId,
@@ -197,9 +186,9 @@ function buildWrapper(
     layoutVersion: storageLayout.layoutVersion,
     namespace,
     baseSlot,
-    storage: items,
-    types,
-  });
+    storage: slimStorageItems(rawItems),
+    types: pickReferencedTypes(rawItems, allTypes),
+  };
 }
 
 /**
@@ -208,13 +197,13 @@ function buildWrapper(
  * "all" mode wraps every open contract under { contracts: [...] }.
  * "full" and "tab" modes export a single contract, full layout or
  * just the active tab respectively. Every payload carries a
- * schemaVersion so consumers can detect format changes.
+ * schemaVersion so consumers can detect format changes. Optional
+ * fields (chainId, address, baseSlot, namespace(s)) are left
+ * undefined when absent, which JSON.stringify drops from the output.
  */
 export function buildExport(opts: SingleOpts | AllOpts): string {
   if (opts.mode === "all") {
-    const contracts = opts.layouts.map((l) =>
-      buildWrapper(l, "full", ROOT_LAYOUT_TAB),
-    );
+    const contracts = opts.layouts.map((l) => buildWrapper(l, "full"));
     return JSON.stringify(
       { schemaVersion: EXPORT_SCHEMA_VERSION, contracts },
       null,
@@ -222,12 +211,6 @@ export function buildExport(opts: SingleOpts | AllOpts): string {
     );
   }
 
-  const entry: LayoutEntry = {
-    contractName: opts.contractName,
-    chainId: opts.chainId,
-    address: opts.address,
-    storageLayout: opts.storageLayout,
-  };
-  const wrapper = buildWrapper(entry, opts.mode, opts.activeTab);
+  const wrapper = buildWrapper(opts, opts.mode, opts.namespace);
   return JSON.stringify(wrapper, null, JSON_INDENT_SPACES);
 }

--- a/src/lib/storage-layout-export.ts
+++ b/src/lib/storage-layout-export.ts
@@ -31,6 +31,13 @@ type AllOpts = {
   layouts: LayoutEntry[];
 };
 
+/**
+ * Strips compiler-internal fields from each storage item.
+ *
+ * Removes `astId` and `src`, which are solc AST pointers
+ * (source file, offset, length) that mean nothing to a
+ * clipboard consumer. Everything else is preserved verbatim.
+ */
 export function slimStorageItems(items: StorageItem[]) {
   return items.map((item) => {
     const copy: Record<string, unknown> = { ...item };
@@ -40,6 +47,16 @@ export function slimStorageItems(items: StorageItem[]) {
   });
 }
 
+/**
+ * Returns only the type entries reachable from the given items.
+ *
+ * The raw `types` dictionary holds every type solc emitted for
+ * the whole compilation unit, most of it unreferenced here. This
+ * does a breadth-first walk starting from each item's `type`,
+ * following struct `members`, plus mapping `key`/`value`, array
+ * `base`, and UDVT `underlying`. The result is minimal but
+ * complete: every type id any copied item points to resolves.
+ */
 export function pickReferencedTypes(
   items: StorageItem[],
   allTypes: RawTypes,
@@ -68,6 +85,13 @@ export function pickReferencedTypes(
   return out;
 }
 
+/**
+ * Returns a shallow copy with all `undefined`-valued keys dropped.
+ *
+ * Keeps optional fields (chainId, address, baseSlot, namespaces)
+ * out of the JSON entirely when they have no value, instead of
+ * serializing them as explicit nulls.
+ */
 function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
   const out: Partial<T> = {};
   for (const k in obj) {
@@ -76,8 +100,15 @@ function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
   return out;
 }
 
-// Derives the absolute ERC-7201 base slot for a "erc7201:<id>" namespace key.
-// Returns undefined for non-namespace strings (e.g. custom-encoded namespaces).
+/**
+ * Derives the absolute ERC-7201 base slot for a namespace key.
+ *
+ * Expects the "erc7201:<id>" convention and computes
+ * keccak256(keccak256(id) - 1) & ~0xff over the id portion.
+ * Returns undefined for any string that is not so prefixed
+ * (for example custom-encoded namespaces), so the caller can
+ * omit the field rather than crash.
+ */
 function deriveNamespaceBaseSlot(namespace: string): string | undefined {
   const prefix = "erc7201:";
   if (!namespace.startsWith(prefix)) return undefined;
@@ -85,6 +116,15 @@ function deriveNamespaceBaseSlot(namespace: string): string | undefined {
   return id.length > 0 ? erc7201(id) : undefined;
 }
 
+/**
+ * Builds the export object for one contract.
+ *
+ * In "full" mode it emits the root storage plus every namespace,
+ * each namespace tagged with its derived baseSlot, and a single
+ * types dictionary covering all of them. In "tab" mode it emits
+ * only the active slice (root or one namespace), with the
+ * namespace tab carrying its own baseSlot and namespace name.
+ */
 function buildWrapper(
   entry: LayoutEntry,
   mode: "full" | "tab",
@@ -162,6 +202,14 @@ function buildWrapper(
   });
 }
 
+/**
+ * Serializes a storage layout to a JSON string for the clipboard.
+ *
+ * "all" mode wraps every open contract under { contracts: [...] }.
+ * "full" and "tab" modes export a single contract, full layout or
+ * just the active tab respectively. Every payload carries a
+ * schemaVersion so consumers can detect format changes.
+ */
 export function buildExport(opts: SingleOpts | AllOpts): string {
   if (opts.mode === "all") {
     const contracts = opts.layouts.map((l) =>


### PR DESCRIPTION
# Description

Relevant issue: https://github.com/GianfrancoBazzani/evm-storage.codes/issues/73

Adds a `Copy Storage Layout` button to the storage-layout visualizer that exports the OpenZeppelin `StorageLayout` to the clipboard as parsable JSON:
<img width="1436" height="189" alt="Screenshot 2026-06-01 at 12 53 08 PM" src="https://github.com/user-attachments/assets/725aafea-2567-41c0-87bc-022eb1caf7a6" />

It shows the user (up to) 3 options: 
1. **Copy full layout**: root storage + all ERC-7201 namespaces for the active contract, each namespace tagged with its derived `baseSlot`,and a BFS-pruned types dictionary so only referenced types are copied. 
2. **Copy current tab**: only the slice currently rendered (root or one namespace). For `namespace` tabs, derives `baseSlot` via `keccak256(keccak256(id) - 1) & ~0xff` so consumers get an absolute slot without re-deriving.
3. **Copy all open contracts** (shown when ≥ 2 contracts are open): every visualizer's full layout wrapped under `{ contracts: [...] }`.

## Output format

1. Every payload is tagged with a `schemaVersion` (`evm-storage.codes/storage-layout-export@1`) so downstream consumers can detect format changes.
2. Per-item compiler internals (`astId`, `src`) are stripped; all layout-relevant fields (`label`, `slot`, `offset`, `type`, `contract`) are preserved verbatim.
3. The types dictionary is pruned with a breadth-first walk from each item's `type`, following struct `members`, mapping `key`/`value`, array `base`, and UDVT `underlying`, so it is minimal but complete: every type id any copied item points to resolves.
4. Optional fields (`chainId`, `address`, `baseSlot`, `namespaces`) are omitted when absent rather than serialized as nulls.

## Implementation notes

1. Export logic lives in a new UI-free module `src/lib/storage-layout-export.ts` (`buildExport` plus pure helpers), so it is independently testable.
2. The visualizer's `Tabs` are now controlled so the copy handler can read the active tab for "Copy current tab".
3. The magic string `"Root layout"` is extracted to a shared `ROOT_LAYOUT_TAB` constant, since the tab UI and the export's root-vs-namespace branch must stay in lockstep.
4. Copy timeouts are cleared on unmount to avoid a state update after the card closes.

## Testing

→ Verified copy output for: a plain root-only contract, a contract with ERC-7201 namespaces (root tab and namespace tab), and the multi-contract "copy all" path.

(example output for `UniswapPoolManager` contract):

```json
{
  "schemaVersion": "evm-storage.codes/storage-layout-export@1",
  "contractName": "PoolManager",
  "chainId": 1,
  "address": "0x000000000004444c5dc75cB358380D2e3dE08A90",
  "layoutVersion": "1.2",
  "storage": [
    {
      "label": "owner",
      "offset": 0,
      "slot": "0",
      "type": "t_address",
      "contract": "Owned"
    },
    {
      "label": "protocolFeesAccrued",
      "offset": 0,
      "slot": "1",
      "type": "t_mapping(t_userDefinedValueType(Currency)35676,t_uint256)",
      "contract": "ProtocolFees"
    },
    {
      "label": "protocolFeeController",
      "offset": 0,
      "slot": "2",
      "type": "t_address",
      "contract": "ProtocolFees"
    },
    {
      "label": "isOperator",
      "offset": 0,
      "slot": "3",
      "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
      "contract": "ERC6909"
    },
    {
      "label": "balanceOf",
      "offset": 0,
      "slot": "4",
      "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))",
      "contract": "ERC6909"
    },
    {
      "label": "allowance",
      "offset": 0,
      "slot": "5",
      "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))",
      "contract": "ERC6909"
    },
    {
      "label": "_pools",
      "offset": 0,
      "slot": "6",
      "type": "t_mapping(t_userDefinedValueType(PoolId)35976,t_struct(State)31944_storage)",
      "contract": "PoolManager"
    }
  ],
  "types": {
    "t_address": {
      "label": "address",
      "numberOfBytes": "20"
    },
    "t_mapping(t_userDefinedValueType(Currency)35676,t_uint256)": {
      "label": "mapping(Currency => uint256)",
      "numberOfBytes": "32"
    },
    "t_mapping(t_address,t_mapping(t_address,t_bool))": {
      "label": "mapping(address => mapping(address => bool))",
      "numberOfBytes": "32"
    },
    "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
      "label": "mapping(address => mapping(uint256 => uint256))",
      "numberOfBytes": "32"
    },
    "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))": {
      "label": "mapping(address => mapping(address => mapping(uint256 => uint256)))",
      "numberOfBytes": "32"
    },
    "t_mapping(t_userDefinedValueType(PoolId)35976,t_struct(State)31944_storage)": {
      "label": "mapping(PoolId => struct Pool.State)",
      "numberOfBytes": "32"
    }
  },
  "namespaces": {}
}
``` 