### PR TITLE
fix: exclude brotli-wasm from Vite dep pre-bundling

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,15 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "src"),
     },
-  }
+  },
+  optimizeDeps: {
+    // brotli-wasm resolves its .wasm binary relative to import.meta.url at
+    // runtime. Vite's dev-server dependency pre-bundling copies the module
+    // into node_modules/.vite/deps/, which moves import.meta.url away from
+    // the .wasm file and breaks that lookup (the dev server then serves the
+    // SPA's index.html for the missing path, which fails to instantiate as
+    // WebAssembly). Excluding it keeps the module served from its original
+    // location, where the relative path still resolves correctly.
+    exclude: ["brotli-wasm"],
+  },
 });


### PR DESCRIPTION
## Summary
- Storage layout loading fails on localhost (`yarn dev`) with `WebAssembly.instantiate(): expected magic word ... found 3c 21 44 4f` (the bytes for `<!DOCTYPE`).
- Root cause: `brotli-wasm`'s "web" target resolves its `.wasm` binary relative to `import.meta.url`. Vite's dev-server dependency pre-bundling copies the module into `node_modules/.vite/deps/`, which moves `import.meta.url` away from the real `pkg.web/brotli_wasm_bg.wasm` file. The resulting fetch 404s and the dev server falls back to serving `index.html`, which `WebAssembly.instantiate()` then chokes on.
- Fix: exclude `brotli-wasm` from `optimizeDeps` in `vite.config.ts` so the dev server serves it from its original location, where the relative wasm lookup resolves correctly. A production `vite build` was never affected, which is why this only reproduced on localhost.

Fixes #87

## Test plan
- [x] Confirmed the failure by requesting the pre-bundled path directly: `GET /node_modules/.vite/deps/brotli_wasm_bg.wasm` returned `200 text/html` (the SPA's `index.html`, whose bytes start with the exact `<!DOCTYPE` sequence from the reported error).
- [x] After the fix, `vite`'s transformed import for `brotli-wasm` points back at `/node_modules/brotli-wasm/index.web.js`, and `GET /node_modules/brotli-wasm/pkg.web/brotli_wasm_bg.wasm` returns `200 application/wasm`.
- [ ] Manual click-through of the storage layout loading flow in a browser (not performed in this environment — no browser automation tool was available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)