### PR TITLE
fix: local dev cache fallback

### DIFF
--- a/api/_lib/upstash.js
+++ b/api/_lib/upstash.js
@@ -1,0 +1,10 @@
+// Upstash Redis is only used for the optional "already compiled this
+// contract before" cache shortcut. External contributors running
+// `yarn vercel dev` without access to the project's Vercel/Upstash
+// credentials should get a clean cache-miss, not a Redis connection error.
+export function hasUpstashCredentials() {
+  return Boolean(
+    (process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL) &&
+      (process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN)
+  );
+}

--- a/api/extract_storage_layout.js
+++ b/api/extract_storage_layout.js
@@ -5,6 +5,7 @@ import {
 import { brotliDecompressSync } from "zlib";
 import { findAll, astDereferencer, isNodeType } from "solidity-ast/utils.js";
 import { Redis } from "@upstash/redis";
+import { hasUpstashCredentials } from "./_lib/upstash.js";
 
 export async function POST(request) {
   try {
@@ -54,7 +55,7 @@ export async function POST(request) {
     );
 
     // Cache the storage layout in the database if it is not already cached
-    if (chainId && address) {
+    if (chainId && address && hasUpstashCredentials()) {
       try {
         // Minimal integrity test
         const response = await fetch(

--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -30,7 +30,7 @@ export async function POST(request) {
     const cacheKey = `${chainId}:${address}`;
     const entry = await redis.get(cacheKey);
 
-    if (!entry.storageLayout) {
+    if (!entry?.storageLayout) {
       return new Response(
         JSON.stringify({ message: "Storage layout not cached." }),
         {

--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -1,4 +1,5 @@
 import { Redis } from "@upstash/redis";
+import { hasUpstashCredentials } from "./_lib/upstash.js";
 
 export async function POST(request) {
   try {
@@ -9,6 +10,16 @@ export async function POST(request) {
         JSON.stringify({ message: "Chain ID and address are required." }),
         {
           status: 400,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    if (!hasUpstashCredentials()) {
+      return new Response(
+        JSON.stringify({ message: "Storage layout not cached." }),
+        {
+          status: 404,
           headers: { "Content-Type": "application/json" },
         }
       );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Landing from "@/components/Landing";
 import Header from "@/components/Header";
 import StorageVisualizer from "@/components/StorageVisualizer";
 import Footer from "./components/Footer";
+import AnalyzeWizardButton from "@/components/AnalyzeWizardButton";
 
 import type { StorageVisualizerProps } from "@/components/StorageVisualizer";
 
@@ -24,6 +25,14 @@ function App() {
   const [storageLayouts, setStorageLayouts] = useState<
     StorageVisualizerProps[]
   >([]);
+
+  // Set when a ?chainId=&address= link misses the storage-layout cache (or
+  // caching isn't configured, e.g. local dev without Upstash credentials),
+  // so the user still lands on a pre-filled ANALYZE ADDRESS wizard instead
+  // of a blank Landing page.
+  const [autoFillTarget, setAutoFillTarget] = useState<
+    { chainId: number; address: string } | undefined
+  >(undefined);
 
   // Parse URL arguments
   const url = new URL(window.location.href);
@@ -42,6 +51,7 @@ function App() {
           body: JSON.stringify({ chainId, address }),
         });
         if (!response.ok) {
+          setAutoFillTarget({ chainId: Number(chainId), address: address! });
           return;
         }
         const data = await response.json();
@@ -56,12 +66,15 @@ function App() {
               address: address ? address : undefined,
             },
           ]);
+        } else {
+          setAutoFillTarget({ chainId: Number(chainId), address: address! });
         }
       } catch (error) {
         console.error(
           `Error fetching cached storage layout for chainId: ${chainId} and address: ${address}:`,
           error
         );
+        setAutoFillTarget({ chainId: Number(chainId), address: address! });
       }
     }
     fetchCachedStorageLayout();
@@ -76,7 +89,15 @@ function App() {
         }}
       >
         {storageLayouts.length === 0 ? (
-          <Landing />
+          <>
+            <Landing />
+            {autoFillTarget && (
+              <AnalyzeWizardButton
+                initialChainId={autoFillTarget.chainId}
+                initialAddress={autoFillTarget.address}
+              />
+            )}
+          </>
         ) : (
           <>
             <div className="flex-grow bg-black text-green-500 px-4">

--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -63,11 +63,18 @@ const ethAddressSchema = z
 interface AnalyzeWizardButtonProps {
   setParentDialogOpen?: Dispatch<SetStateAction<boolean>>;
   triggerVisualizerId?: number;
+  // Pre-fill and auto-open the wizard for a given chain/address (used by
+  // App.tsx to recover from a storage-layout cache miss on ?chainId=&address=
+  // links) instead of requiring the user to open the dialog manually.
+  initialChainId?: number;
+  initialAddress?: string;
 }
 
 export default function AnalyzeWizardButton({
   setParentDialogOpen = undefined,
   triggerVisualizerId = undefined,
+  initialChainId = undefined,
+  initialAddress = undefined,
 }: AnalyzeWizardButtonProps) {
   // Global context
   const storageLayoutsContext = useContext(StorageLayoutsContext);
@@ -77,7 +84,9 @@ export default function AnalyzeWizardButton({
   const { setStorageLayouts } = storageLayoutsContext;
 
   // New state to control the dialog's open/close state.
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(
+    Boolean(initialChainId && initialAddress)
+  );
 
   // Wizard step
   enum WizardStep {
@@ -131,8 +140,18 @@ export default function AnalyzeWizardButton({
     fetchChains();
   }, []);
 
+  // Pre-select the chain once the chains list has loaded, when opened with
+  // an initialChainId (see AnalyzeWizardButtonProps above).
+  useEffect(() => {
+    if (initialChainId === undefined || chains.length === 0) return;
+    const matchedChain = chains.find((_chain) => _chain.chainId === initialChainId);
+    if (matchedChain) {
+      setChainName(matchedChain.name);
+    }
+  }, [chains, initialChainId]);
+
   // Address management with zod validation
-  const [address, setAddress] = useState<string | undefined>(undefined);
+  const [address, setAddress] = useState<string | undefined>(initialAddress);
   const [addressError, setAddressError] = useState<string | undefined>(
     undefined
   );
@@ -528,14 +547,16 @@ export default function AnalyzeWizardButton({
 
   return (
     <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-      <DialogTrigger asChild>
-        <Button
-          className="w-52 bg-green-900/30 text-green-500 border border-green-500 hover:bg-green-600/40 hover:text-green-300 transition-all duration-300 px-8 py-6 text-lg animate-pulse"
-          onClick={() => setDialogOpen(true)}
-        >
-          <Upload className="mr-2 h-4 w-4" /> ANALYZE ADDRESS
-        </Button>
-      </DialogTrigger>
+      {!initialAddress && (
+        <DialogTrigger asChild>
+          <Button
+            className="w-52 bg-green-900/30 text-green-500 border border-green-500 hover:bg-green-600/40 hover:text-green-300 transition-all duration-300 px-8 py-6 text-lg animate-pulse"
+            onClick={() => setDialogOpen(true)}
+          >
+            <Upload className="mr-2 h-4 w-4" /> ANALYZE ADDRESS
+          </Button>
+        </DialogTrigger>
+      )}
 
       {/* Wizard Step 1: Select Network and Address */}
       {wizardStep === WizardStep.SELECT_ADDRESS && (


### PR DESCRIPTION
## Summary
- External contributors running `yarn vercel dev` without access to this project's Vercel/Upstash credentials couldn't load a storage layout at all, even though the compile pipeline itself has no hard dependency on Redis.
- `api/get_cached_storage_layout.js` and `api/extract_storage_layout.js` now use a shared `hasUpstashCredentials()` guard (`api/_lib/upstash.js`) to skip Redis entirely when credentials aren't configured, instead of letting the call fail (surfacing a misleading 500 from the cached-layout lookup). Production behavior is unchanged, since credentials are always configured there.
- Separately, `src/App.tsx`'s `?chainId=&address=` cache lookup had no fallback when the cache missed or errored — it silently did nothing, contradicting `CLAUDE.md`'s documented "falls back to the normal fetch-and-compile wizard flow" behavior. `AnalyzeWizardButton` now accepts optional `initialChainId`/`initialAddress` props; on a cache miss, `App.tsx` renders it pre-filled (network + address already set) so the user lands one click away from compiling, instead of a blank Landing page. This also fixes the same latent gap in production for any share link to a not-yet-cached contract.

Fixes GianfrancoBazzani/evm-storage.codes#92

**Base branch note**: this PR is stacked on GianfrancoBazzani/evm-storage.codes#91 (`fix/clarify-local-development-docs`) since it builds on that README context — only the two commits above are new. Once #91 merges to `main`, this should be retargeted (or reopened) against `main` upstream, at which point the diff will shrink to just those two commits.

## Test plan
- [x] `yarn build` / `yarn lint` clean on touched files.
- [x] Verified end-to-end against a real `yarn vercel dev` session and direct handler invocation with a zeroed-out environment: `get_cached_storage_layout` now returns a clean 404 instead of 500 with no Upstash credentials configured.
- [x] Regression check: `extract_storage_layout` still returns a full storage layout (verified against a real Sourcify + solc compile for `0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984` on mainnet) with zero Upstash env vars set.
- [ ] Manual click-through of the `?chainId=&address=` auto-fill flow in a real browser (not performed in this environment — no browser automation tool was available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)