### PR TITLE
fix: scope multi-slot item tooltips to their own row

### DIFF
--- a/api/_lib/upstash.js
+++ b/api/_lib/upstash.js
@@ -1,0 +1,10 @@
+// Upstash Redis is only used for the optional "already compiled this
+// contract before" cache shortcut. External contributors running
+// `yarn vercel dev` without access to the project's Vercel/Upstash
+// credentials should get a clean cache-miss, not a Redis connection error.
+export function hasUpstashCredentials() {
+  return Boolean(
+    (process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL) &&
+      (process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN)
+  );
+}

--- a/api/extract_storage_layout.js
+++ b/api/extract_storage_layout.js
@@ -5,6 +5,7 @@ import {
 import { brotliDecompressSync } from "zlib";
 import { findAll, astDereferencer, isNodeType } from "solidity-ast/utils.js";
 import { Redis } from "@upstash/redis";
+import { hasUpstashCredentials } from "./_lib/upstash.js";
 
 export async function POST(request) {
   try {
@@ -54,7 +55,7 @@ export async function POST(request) {
     );
 
     // Cache the storage layout in the database if it is not already cached
-    if (chainId && address) {
+    if (chainId && address && hasUpstashCredentials()) {
       try {
         // Minimal integrity test
         const response = await fetch(

--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -30,7 +30,7 @@ export async function POST(request) {
     const cacheKey = `${chainId}:${address}`;
     const entry = await redis.get(cacheKey);
 
-    if (!entry.storageLayout) {
+    if (!entry?.storageLayout) {
       return new Response(
         JSON.stringify({ message: "Storage layout not cached." }),
         {

--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -1,4 +1,5 @@
 import { Redis } from "@upstash/redis";
+import { hasUpstashCredentials } from "./_lib/upstash.js";
 
 export async function POST(request) {
   try {
@@ -9,6 +10,16 @@ export async function POST(request) {
         JSON.stringify({ message: "Chain ID and address are required." }),
         {
           status: 400,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    if (!hasUpstashCredentials()) {
+      return new Response(
+        JSON.stringify({ message: "Storage layout not cached." }),
+        {
+          status: 404,
           headers: { "Content-Type": "application/json" },
         }
       );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Landing from "@/components/Landing";
 import Header from "@/components/Header";
 import StorageVisualizer from "@/components/StorageVisualizer";
 import Footer from "./components/Footer";
+import AnalyzeWizardButton from "@/components/AnalyzeWizardButton";
 
 import type { StorageVisualizerProps } from "@/components/StorageVisualizer";
 
@@ -24,6 +25,14 @@ function App() {
   const [storageLayouts, setStorageLayouts] = useState<
     StorageVisualizerProps[]
   >([]);
+
+  // Set when a ?chainId=&address= link misses the storage-layout cache (or
+  // caching isn't configured, e.g. local dev without Upstash credentials),
+  // so the user still lands on a pre-filled ANALYZE ADDRESS wizard instead
+  // of a blank Landing page.
+  const [autoFillTarget, setAutoFillTarget] = useState<
+    { chainId: number; address: string } | undefined
+  >(undefined);
 
   // Parse URL arguments
   const url = new URL(window.location.href);
@@ -42,6 +51,7 @@ function App() {
           body: JSON.stringify({ chainId, address }),
         });
         if (!response.ok) {
+          setAutoFillTarget({ chainId: Number(chainId), address: address! });
           return;
         }
         const data = await response.json();
@@ -56,12 +66,15 @@ function App() {
               address: address ? address : undefined,
             },
           ]);
+        } else {
+          setAutoFillTarget({ chainId: Number(chainId), address: address! });
         }
       } catch (error) {
         console.error(
           `Error fetching cached storage layout for chainId: ${chainId} and address: ${address}:`,
           error
         );
+        setAutoFillTarget({ chainId: Number(chainId), address: address! });
       }
     }
     fetchCachedStorageLayout();
@@ -76,7 +89,15 @@ function App() {
         }}
       >
         {storageLayouts.length === 0 ? (
-          <Landing />
+          <>
+            <Landing />
+            {autoFillTarget && (
+              <AnalyzeWizardButton
+                initialChainId={autoFillTarget.chainId}
+                initialAddress={autoFillTarget.address}
+              />
+            )}
+          </>
         ) : (
           <>
             <div className="flex-grow bg-black text-green-500 px-4">

--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -63,11 +63,18 @@ const ethAddressSchema = z
 interface AnalyzeWizardButtonProps {
   setParentDialogOpen?: Dispatch<SetStateAction<boolean>>;
   triggerVisualizerId?: number;
+  // Pre-fill and auto-open the wizard for a given chain/address (used by
+  // App.tsx to recover from a storage-layout cache miss on ?chainId=&address=
+  // links) instead of requiring the user to open the dialog manually.
+  initialChainId?: number;
+  initialAddress?: string;
 }
 
 export default function AnalyzeWizardButton({
   setParentDialogOpen = undefined,
   triggerVisualizerId = undefined,
+  initialChainId = undefined,
+  initialAddress = undefined,
 }: AnalyzeWizardButtonProps) {
   // Global context
   const storageLayoutsContext = useContext(StorageLayoutsContext);
@@ -77,7 +84,9 @@ export default function AnalyzeWizardButton({
   const { setStorageLayouts } = storageLayoutsContext;
 
   // New state to control the dialog's open/close state.
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(
+    Boolean(initialChainId && initialAddress)
+  );
 
   // Wizard step
   enum WizardStep {
@@ -131,8 +140,18 @@ export default function AnalyzeWizardButton({
     fetchChains();
   }, []);
 
+  // Pre-select the chain once the chains list has loaded, when opened with
+  // an initialChainId (see AnalyzeWizardButtonProps above).
+  useEffect(() => {
+    if (initialChainId === undefined || chains.length === 0) return;
+    const matchedChain = chains.find((_chain) => _chain.chainId === initialChainId);
+    if (matchedChain) {
+      setChainName(matchedChain.name);
+    }
+  }, [chains, initialChainId]);
+
   // Address management with zod validation
-  const [address, setAddress] = useState<string | undefined>(undefined);
+  const [address, setAddress] = useState<string | undefined>(initialAddress);
   const [addressError, setAddressError] = useState<string | undefined>(
     undefined
   );
@@ -528,14 +547,16 @@ export default function AnalyzeWizardButton({
 
   return (
     <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-      <DialogTrigger asChild>
-        <Button
-          className="w-52 bg-green-900/30 text-green-500 border border-green-500 hover:bg-green-600/40 hover:text-green-300 transition-all duration-300 px-8 py-6 text-lg animate-pulse"
-          onClick={() => setDialogOpen(true)}
-        >
-          <Upload className="mr-2 h-4 w-4" /> ANALYZE ADDRESS
-        </Button>
-      </DialogTrigger>
+      {!initialAddress && (
+        <DialogTrigger asChild>
+          <Button
+            className="w-52 bg-green-900/30 text-green-500 border border-green-500 hover:bg-green-600/40 hover:text-green-300 transition-all duration-300 px-8 py-6 text-lg animate-pulse"
+            onClick={() => setDialogOpen(true)}
+          >
+            <Upload className="mr-2 h-4 w-4" /> ANALYZE ADDRESS
+          </Button>
+        </DialogTrigger>
+      )}
 
       {/* Wizard Step 1: Select Network and Address */}
       {wizardStep === WizardStep.SELECT_ADDRESS && (

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -431,63 +431,56 @@ export default function StorageVisualizer({
               key={index}
               className=" px-4 pb-4 overflow-x-auto text-green-500 text-sm leading-relaxed"
             >
-              {layout.slots.map((slot, index) => (
-                <div className=" flex flex-row my-0.5 ">
-                  <div className="w-5 text-[11px]">{index}</div>
-                  <div key={index} className=" h-[1.2rem] w-full relative ">
-                    {slot.map((item, index) => (
-                      <div key={index} className=" flex flex-col">
-                        <Tooltip
-                          open={Boolean(
-                            visibleTooltips[
-                              `${layout.name}|${
-                                storageLayout?.types[item.item.type].label
-                              }|${item.item.label}`
-                            ] ||
-                              pinnedTooltips[
-                                `${layout.name}|${
-                                  storageLayout?.types[item.item.type].label
-                                }|${item.item.label}`
-                              ]
-                          )}
-                          onOpenChange={(isOpen) =>
-                            handleOpenTooltip(
-                              `${layout.name}|${
-                                storageLayout?.types[item.item.type].label
-                              }|${item.item.label}`,
-                              isOpen
-                            )
-                          }
-                        >
-                          <TooltipTrigger
-                            asChild
-                            onClick={() => {
-                              handlePinTooltip(
-                                `${layout.name}|${
-                                  storageLayout?.types[item.item.type].label
-                                }|${item.item.label}`
-                              );
-                            }}
+              {layout.slots.map((slot, slotIndex) => (
+                <div key={slotIndex} className=" flex flex-row my-0.5 ">
+                  <div className="w-5 text-[11px]">{slotIndex}</div>
+                  <div className=" h-[1.2rem] w-full relative ">
+                    {slot.map((item, itemIndex) => {
+                      // Include the row/segment position in the key: an
+                      // item spanning multiple slots (e.g. uint256[80])
+                      // repeats the same label/type on every row it
+                      // occupies, so without this each segment would share
+                      // one tooltip state and all open together on hover.
+                      const tooltipKey = `${layout.name}|${
+                        storageLayout?.types[item.item.type].label
+                      }|${item.item.label}|${slotIndex}|${itemIndex}`;
+                      return (
+                        <div key={itemIndex} className=" flex flex-col">
+                          <Tooltip
+                            open={Boolean(
+                              visibleTooltips[tooltipKey] ||
+                                pinnedTooltips[tooltipKey]
+                            )}
+                            onOpenChange={(isOpen) =>
+                              handleOpenTooltip(tooltipKey, isOpen)
+                            }
                           >
-                            <div
-                              style={{
-                                width: `${item.width}%`,
-                                left: `${item.offset}%`,
-                                backgroundColor: item.color,
+                            <TooltipTrigger
+                              asChild
+                              onClick={() => {
+                                handlePinTooltip(tooltipKey);
                               }}
-                              className="h-full absolute border border-green-500"
-                            />
-                          </TooltipTrigger>
-                          <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
-                            <span>
-                              {`${
-                                storageLayout?.types[item.item.type].label
-                              } | ${item.item.label}`}
-                            </span>
-                          </TooltipContent>
-                        </Tooltip>
-                      </div>
-                    ))}
+                            >
+                              <div
+                                style={{
+                                  width: `${item.width}%`,
+                                  left: `${item.offset}%`,
+                                  backgroundColor: item.color,
+                                }}
+                                className="h-full absolute border border-green-500"
+                              />
+                            </TooltipTrigger>
+                            <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
+                              <span>
+                                {`${
+                                  storageLayout?.types[item.item.type].label
+                                } | ${item.item.label}`}
+                              </span>
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                      );
+                    })}
                   </div>
                   <div className="h-[2px]" />
                 </div>


### PR DESCRIPTION
## Summary
- An item spanning multiple slots (e.g. a `uint256[80] __gap` array) is drawn once per row it occupies, but its tooltip open/pinned state in `StorageVisualizer.tsx` was keyed only by `layoutName|typeLabel|itemLabel` — identical across every row for the same item.
- Hovering or clicking any one row's segment set that shared key to `true`, so every `<Tooltip>` reading that same key opened simultaneously, stacking dozens of duplicate tooltip bubbles down the page.
- Fix: fold the row index and in-row position into the tooltip key so each segment tracks its own open/pinned state independently, matching how single-slot items already behave. Also fixed a couple of adjacent `.map()` calls missing a `key` prop on the actual mapped element while touching this block.

Fixes GianfrancoBazzani/evm-storage.codes#55

**Base branch note**: stacked on `fix/local-dev-cache-fallback` (itself stacked on #91), same reasoning as that PR — only this one commit is new here.

## Test plan
- [x] `yarn build` clean; no new lint errors introduced (pre-existing `StorageVisualizer.tsx` lint issues are untouched, in code this PR doesn't modify).
- [x] Reproduced the bug against the exact repro case (chain 1 / `0x40aA958dd87FC8305b97f2BA922CDdCa374bcD7f`, `TokenApprove`, which has two `uint256[50]`/`uint256[49]` `__gap` arrays): with the original code, hovering a gap-array row opened 50 stacked tooltip bubbles (verified via a scripted Playwright session, screenshot matches the reported bug pixel-for-pixel).
- [x] With the fix, hovering the same row opens exactly 1 tooltip bubble (`uint256[50] | __gap`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)