### PR TITLE
fix: collapse huge multi-slot storage items into a single row

### DIFF
--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -23,6 +23,7 @@ import ComparisonWizardButton from "@/components/ComparisonWizardButton";
 import ColorHash from "color-hash";
 import { normalizeUint256Literal } from "@/lib/integer-literals";
 import { erc7201 } from "@/lib/erc7201";
+import { MAX_CONTIGUOUS_ITEM_SLOT_ROWS } from "@/lib/constants";
 
 import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
 
@@ -107,8 +108,17 @@ export default function StorageVisualizer({
     offset: Number;
   }
 
+  // A single displayed row. Usually one row is one slot (label is that slot
+  // number), but an item spanning more than MAX_CONTIGUOUS_ITEM_SLOT_ROWS
+  // slots (e.g. a large __gap array) is collapsed into one row covering the
+  // whole range instead of one row per slot it occupies.
+  interface SlotRow {
+    items: ItemWrapper[];
+    label: string;
+  }
+
   interface StorageLayoutWrapper {
-    slots: ItemWrapper[][];
+    slots: SlotRow[];
     name: string;
     baseSlot: string;
   }
@@ -141,7 +151,7 @@ export default function StorageVisualizer({
     });
 
     let maxSlot = 0;
-    let slots: Array<Array<ItemWrapper>> = [];
+    let slots: Array<SlotRow> = [];
     if (storageItems.length > 0) {
       // Set maxSlot
       maxSlot = Number(
@@ -165,9 +175,39 @@ export default function StorageVisualizer({
       let overflowBytes = 0;
       for (let i = 0; i <= maxSlot; i++) {
         let slotItems = storageItems.filter((item) => Number(item.slot) === i);
+
+        // An item spanning more slots than MAX_CONTIGUOUS_ITEM_SLOT_ROWS
+        // (e.g. a large __gap array) is collapsed into a single row instead
+        // of one row per slot: rendering thousands of rows/tooltips makes
+        // the page unresponsive for no visual benefit, since every one of
+        // those rows would look identical anyway.
+        if (overflowBytes === 0 && slotItems.length === 1) {
+          const itemNumberOfBytes = Number(
+            storageLayout?.types[slotItems[0].type].numberOfBytes
+          );
+          const itemSlotSpan = Math.ceil(itemNumberOfBytes / 32);
+          if (itemSlotSpan > MAX_CONTIGUOUS_ITEM_SLOT_ROWS) {
+            const item = slotItems[0];
+            const endSlot = i + itemSlotSpan - 1;
+            slots.push({
+              items: [
+                {
+                  item,
+                  color: idToColor[`${item.contract}:${item.label}`],
+                  width: 100,
+                  offset: 0,
+                },
+              ],
+              label: `${i}–${endSlot}`,
+            });
+            i = endSlot;
+            continue;
+          }
+        }
+
         // if previous slot is overflown
         if (overflowBytes > 0) {
-          slotItems?.unshift(slots[i - 1].slice(-1)[0].item);
+          slotItems?.unshift(slots[slots.length - 1].items.slice(-1)[0].item);
         }
         // compute bytes used by storage objects in the slot it can overflow
         let bytesUsed = overflowBytes;
@@ -206,7 +246,7 @@ export default function StorageVisualizer({
         } else {
           overflowBytes = 0;
         }
-        slots.push(slotItemsWrapped);
+        slots.push({ items: slotItemsWrapped, label: String(i) });
       }
     }
     return {
@@ -431,11 +471,13 @@ export default function StorageVisualizer({
               key={index}
               className=" px-4 pb-4 overflow-x-auto text-green-500 text-sm leading-relaxed"
             >
-              {layout.slots.map((slot, slotIndex) => (
-                <div key={slotIndex} className=" flex flex-row my-0.5 ">
-                  <div className="w-5 text-[11px]">{slotIndex}</div>
+              {layout.slots.map((row, rowIndex) => (
+                <div key={rowIndex} className=" flex flex-row my-0.5 ">
+                  <div className="min-w-5 shrink-0 pr-1 text-[11px]">
+                    {row.label}
+                  </div>
                   <div className=" h-[1.2rem] w-full relative ">
-                    {slot.map((item, itemIndex) => {
+                    {row.items.map((item, itemIndex) => {
                       // Include the row/segment position in the key: an
                       // item spanning multiple slots (e.g. uint256[80])
                       // repeats the same label/type on every row it
@@ -443,7 +485,7 @@ export default function StorageVisualizer({
                       // one tooltip state and all open together on hover.
                       const tooltipKey = `${layout.name}|${
                         storageLayout?.types[item.item.type].label
-                      }|${item.item.label}|${slotIndex}|${itemIndex}`;
+                      }|${item.item.label}|${rowIndex}|${itemIndex}`;
                       return (
                         <div key={itemIndex} className=" flex flex-col">
                           <Tooltip

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,3 +13,8 @@ export const EVM_VERSIONS = [
   "constantinople",
 ];
 export const BROTLI_QUALITY = 9;
+// Storage items (e.g. `__gap` arrays) can legitimately span thousands of
+// slots. Rendering one DOM row + tooltip per slot for those makes the page
+// unresponsive, so a single item spanning more slots than this is collapsed
+// into one summary row instead of one row per slot it occupies.
+export const MAX_CONTIGUOUS_ITEM_SLOT_ROWS = 200;


### PR DESCRIPTION
## Summary
- An item spanning many slots (e.g. a large `__gap` array) made `StorageVisualizer` render one DOM row + Radix `Tooltip` per slot it occupies. That's fine for normal-sized gaps (50-100 slots), but for a genuinely huge item it makes the page unresponsive.
- Reproduced against the example from the issue (chain 1 / `0x580E40c15261F7Baf18eA50F562118aE99361096`, `PendleMarketV3`), which has a `struct OracleLib.Observation[65535]` array — spanning **65,535 slots**.
- Fix: items spanning more than `MAX_CONTIGUOUS_ITEM_SLOT_ROWS` (200, new constant in `src/lib/constants.ts`) slots are now collapsed into a single summary row labeled with their slot range (e.g. `12–65546`) instead of one row per slot. Normal-sized items (including the `__gap[50]`/`__gap[49]` arrays from #55/#56, well under the threshold) are unaffected — still one row per slot, unchanged.

Fixes GianfrancoBazzani/evm-storage.codes#61

The working example now loads without crashing and looks as follows:

<img width="1457" height="479" alt="image" src="https://github.com/user-attachments/assets/c3d4cdcf-b45f-468c-ac56-578048866fc3" />


**Other edge cases considered**: the "takes a long time to load" part of the report is real Solidity compile time for a genuinely large/complex contract (further amplified by ERC-7201 namespaced-compilation triggering, since this contract is solc 0.8.24) — that's an inherent cost, not a bug, and out of scope here. The actual bug — and the only part in scope for a "style" issue about the *display* — is the page becoming unresponsive once the layout is ready to render, which this PR fixes. I didn't find other distinct edge cases in this area; happy to revisit if you have another repro in mind.

**Base branch note**: stacked on `fix/56-loading-spinner-cached-layout` (itself stacked on `fix/55-multi-slot-tooltip` → `fix/local-dev-cache-fallback` → #91), same reasoning as those — only this one commit is new here.

## Test plan
- [x] `yarn build` clean; no new lint issues (pre-existing `StorageVisualizer.tsx` lint issues are untouched, in code this PR doesn't modify).
- [x] End-to-end verified with a scripted Playwright session against a running `yarn vercel dev`, using the exact address from the issue: rendering now produces 13 rows (matching the 13 actual storage items) instead of ~65,547, and the page stays fully responsive (3ms JS eval round-trip measured immediately after render).
- [x] Hovering the collapsed row still opens exactly one correct tooltip (`struct OracleLib.Observation[65535] | observations`), consistent with the #55 fix.
- [x] Regression check: `TokenApprove` (chain 1 / `0x40aA958dd87FC8305b97f2BA922CDdCa374bcD7f`, the #55/#56 example with `__gap[50]`/`__gap[49]`) still renders 102 individual rows, unaffected by the new threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)