### PR TITLE
feat: unwrap struct fields in the storage visualizer

### DIFF
--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -25,10 +25,52 @@ import { normalizeUint256Literal } from "@/lib/integer-literals";
 import { erc7201 } from "@/lib/erc7201";
 import { MAX_CONTIGUOUS_ITEM_SLOT_ROWS } from "@/lib/constants";
 
-import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
+import type {
+  StorageLayout,
+  StorageItem,
+  TypeItem,
+  TypeItemMembers,
+  StructMember,
+} from "@openzeppelin/upgrades-core";
 
 const SLOT_ZERO =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+// A type's `members` is either struct fields or enum value names (plain
+// strings) - only the former has its own slot/offset layout to unwrap.
+function isStructMembers(members: TypeItemMembers): members is StructMember[] {
+  return members.length === 0 || typeof members[0] !== "string";
+}
+
+// Replaces struct-typed items with one synthetic item per field (dot-joined
+// label, e.g. "testStorage.a") so struct internals display the same way as
+// top-level variables instead of one opaque blob. Recurses for nested
+// structs. Arrays of structs and mappings are left as-is: their members
+// don't have static slots to unwrap this way.
+function unwrapStructItems(
+  items: StorageItem[],
+  types: Record<string, TypeItem>
+): StorageItem[] {
+  const result: StorageItem[] = [];
+  for (const item of items) {
+    const members = types[item.type]?.members;
+    if (members && isStructMembers(members)) {
+      const fieldItems: StorageItem[] = members.map((member) => ({
+        astId: item.astId,
+        contract: item.contract,
+        label: `${item.label}.${member.label}`,
+        type: member.type,
+        src: item.src,
+        offset: member.offset,
+        slot: (BigInt(item.slot ?? 0) + BigInt(member.slot ?? 0)).toString(),
+      }));
+      result.push(...unwrapStructItems(fieldItems, types));
+    } else {
+      result.push(item);
+    }
+  }
+  return result;
+}
 
 export interface StorageVisualizerProps {
   contractName: string;
@@ -131,6 +173,14 @@ export default function StorageVisualizer({
     baseSlot: string,
     isNamespace: boolean = false
   ): StorageLayoutWrapper {
+    // Unwrap struct fields so they display individually instead of as one
+    // opaque blob spanning the struct's full size. Must run before the
+    // baseSlot normalization below: struct members' slots (from
+    // storageLayout.types) are always decimal, while normalization
+    // rewrites .slot to an unprefixed hex string, which BigInt() can't
+    // parse back consistently.
+    storageItems = unwrapStructItems(storageItems, storageLayout.types);
+
     // Normalize baseSlot if is custom
     if (!isNamespace && baseSlot !== SLOT_ZERO) {
       let storageItemsNormalized = JSON.parse(JSON.stringify(storageItems));


### PR DESCRIPTION
## Summary
- A struct-typed storage item rendered as one opaque blob spanning the struct's full size, with a single generic `struct X | label` tooltip — the individual fields and their exact byte ranges weren't visible (matches the issue's repro exactly).
- Adds `unwrapStructItems()` in `StorageVisualizer.tsx`, which replaces a struct item with one synthetic item per field *before* the existing slot-building logic runs — no changes needed to that logic, it already handles arbitrary flat items generically. Uses dot-joined labels (e.g. `testStorage.a`) and slot arithmetic (struct member slots in solc's `storageLayout` are relative to the struct's own start, so `absoluteSlot = structItem.slot + member.slot`). Recurses for nested structs.
- Deliberately out of scope: arrays of structs and mappings-of-structs. Their members don't have static slots to unwrap this way (array elements would need per-index expansion, mappings' values live at dynamic keccak256-derived slots) — they keep rendering as a single item, same as today.

Fixes GianfrancoBazzani/evm-storage.codes#66

Note: This unwraps inline struct variables and nested inline struct fields. It intentionally does not unwrap mappings or dynamic arrays of structs into storage rows, because those values do not have concrete contiguous storage slots without runtime keys.

After this PR the storage layout representation of, e.g., the UniswapV3Pool contract (0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640 on mainnet) would look like this:

<img width="1459" height="403" alt="image" src="https://github.com/user-attachments/assets/359a372f-029c-46f7-b8b1-87bf6713d1cc" />

instead of this:

<img width="1450" height="752" alt="image" src="https://github.com/user-attachments/assets/49c7d317-f609-49f3-8186-b46ec3a96df6" />

**Base branch note**: stacked on `fix/61-large-gap-array-edgecases` (itself stacked on #56 → #55 → `fix/local-dev-cache-fallback` → #91), same reasoning as those — only this one commit is new here.

## Test plan
- [x] `yarn build` clean; no new lint issues (pre-existing `StorageVisualizer.tsx` lint issues are untouched, in code this PR doesn't modify).
- [x] End-to-end verified via file upload (Playwright) using the exact contract from the issue (`bool a; address b; uint40 c; bytes32 d;`): now renders as 2 slots with 3 fields correctly split in slot 0 (`bool|testStorage.a` width 3.125%/offset 0%, `address|testStorage.b` width 62.5%/offset 3.125%, `uint40|testStorage.c` width 15.625%/offset 65.625%) and 1 field in slot 1 (`bytes32|testStorage.d` width 100%), matching the expected byte layout exactly.
- [x] Nested-struct case verified (`Outer { bool flag; Inner inner; uint256 z; }` where `Inner { uint128 x; uint128 y; }`): renders as `outer.flag` (slot 1), `outer.inner.x` + `outer.inner.y` packed together (slot 2), `outer.z` (slot 3) — matching Solidity's actual packing rules (nested struct/array members always start a fresh slot).
- [x] Regression-checked against the #55/#56 `TokenApprove` example (no structs involved): unaffected, still renders 102 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)