### PR TITLE
🔨 fix: use current origin for in-app links to make them deployment specific

### DIFF
--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -80,7 +80,7 @@ export default function Landing() {
             {examples.map((example, index) => (
               <li key={index}>
                 <a
-                  href={`https://evm-storage.codes/?address=${example.address}&chainId=${example.chainId}`}
+                  href={`/?address=${example.address}&chainId=${example.chainId}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline"

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -304,7 +304,7 @@ export default function StorageVisualizer({
                     onClick={async () => {
                       try {
                         await navigator.clipboard.writeText(
-                          `https://evm-storage.codes/?address=${address}&chainId=${chainId}`
+                          `${window.location.origin}/?address=${address}&chainId=${chainId}`
                         );
                         if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
                         setCopied(true);


### PR DESCRIPTION
## Summary

Fixes #101 — links generated inside the app hardcoded `https://evm-storage.codes`, so preview/release deployments produced links that pointed back to the production app.

- **Share storage layout button** (`StorageVisualizer.tsx`): the copied share link now uses `window.location.origin`, so it points at whichever deployment the user is on.
- **Example storage layout links** (`Landing.tsx`): now plain relative hrefs (`/?address=…&chainId=…`), which resolve against the current deployment.

External links (GitHub repo, Sourcify, buymeacoffee) and the `og:`/canonical meta tags in `index.html` intentionally still point at their absolute targets.

## Verification

- `tsc -b` passes
- `eslint` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)