### PR TITLE
💅 style: use theme green for focus rings

### DIFF
--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -351,95 +351,105 @@ export default function AnalyzeWizardButton({
   }
 
   // Compile Namespaces useEffect
-  async function compileNamespaces() {
-    try {
-      // To avoid FUNCTION_PAYLOAD_TOO_LARGE compress the  data using brotli
-      const _brotli = await brotliPromise;
-      const _textEncoder = new TextEncoder();
-      const _compilerVersionSemver =
-        compilerBinary.match(/v(\d+\.\d+\.\d+)/)?.[1];
-      const _uncompressedBodyRequest = _textEncoder.encode(
-        JSON.stringify({
-          solcInput: solcInput,
-          solcOutput: solcOutput,
-          compilerVersion: _compilerVersionSemver,
-        })
-      );
-      const _compressedBodyRequest = _brotli.compress(
-        _uncompressedBodyRequest,
-        {
-          quality: BROTLI_QUALITY,
-        }
-      );
-
-      // Generate namespaced compiler input in the backend
-      const response = await fetch("/api/get_namespaced_input", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/octet-stream",
-        },
-        body: new Uint8Array(_compressedBodyRequest),
-      });
-      if (!response.ok) {
-        throw new Error((await response.json()).message);
-      }
-      
-      // Decode the response
-      const _arrayBuffer = await response.arrayBuffer();
-      const _textDecoder = new TextDecoder();
-      const _namespacedInput = JSON.parse(
-        _textDecoder.decode(_arrayBuffer)
-      );
-
-      //  Compile contract using compiler worker
-      const worker = new Worker("/dynSolcWorkerBundle.js");
-      worker.addEventListener(
-        "message",
-        (msg) => {
-          const _namespacedOutput: SolcOutput = JSON.parse(msg.data.solcOutput);
-          setNamespacedOutput(_namespacedOutput);
-          if (
-            _namespacedOutput.errors &&
-            _namespacedOutput.errors.some(
-              (error: { severity: string }) => error.severity === "error"
-            )
-          ) {
-            setWizardStep(WizardStep.COMPILATION_ERROR);
-          } else {
-            setWizardStep(WizardStep.SELECT_CONTRACT);
-          }
-          worker.terminate();
-        },
-        false
-      );
-      worker.postMessage({
-        solcInput: JSON.stringify(_namespacedInput),
-        solcBin: compilerBinary,
-      });
-    } catch (error) {
-      const _solcOutput: SolcOutput = {
-        errors: [
-          {
-            severity: "error",
-            formattedMessage: "Error compiling namespaces: " + error,
-          },
-        ],
-        contracts: {},
-        sources: {},
-      };
-      setSolcOutput(_solcOutput);
-      setWizardStep(WizardStep.COMPILATION_ERROR);
-      return;
-    }
-  }
   useEffect(() => {
     if (
-      wizardStep === WizardStep.COMPILING_NAMESPACED &&
-      solcOutput !== undefined
+      wizardStep !== WizardStep.COMPILING_NAMESPACED ||
+      solcOutput === undefined
     ) {
-      compileNamespaces();
+      return;
     }
-  }, [wizardStep]);
+    compileNamespaces();
+
+    async function compileNamespaces() {
+      try {
+        // To avoid FUNCTION_PAYLOAD_TOO_LARGE compress the  data using brotli
+        const _brotli = await brotliPromise;
+        const _textEncoder = new TextEncoder();
+        const _compilerVersionSemver =
+          compilerBinary.match(/v(\d+\.\d+\.\d+)/)?.[1];
+        const _uncompressedBodyRequest = _textEncoder.encode(
+          JSON.stringify({
+            solcInput: solcInput,
+            solcOutput: solcOutput,
+            compilerVersion: _compilerVersionSemver,
+          })
+        );
+        const _compressedBodyRequest = _brotli.compress(
+          _uncompressedBodyRequest,
+          {
+            quality: BROTLI_QUALITY,
+          }
+        );
+
+        // Generate namespaced compiler input in the backend
+        const response = await fetch("/api/get_namespaced_input", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/octet-stream",
+          },
+          body: new Uint8Array(_compressedBodyRequest),
+        });
+        if (!response.ok) {
+          throw new Error((await response.json()).message);
+        }
+      
+        // Decode the response
+        const _arrayBuffer = await response.arrayBuffer();
+        const _textDecoder = new TextDecoder();
+        const _namespacedInput = JSON.parse(
+          _textDecoder.decode(_arrayBuffer)
+        );
+
+        //  Compile contract using compiler worker
+        const worker = new Worker("/dynSolcWorkerBundle.js");
+        worker.addEventListener(
+          "message",
+          (msg) => {
+            const _namespacedOutput: SolcOutput = JSON.parse(msg.data.solcOutput);
+            setNamespacedOutput(_namespacedOutput);
+            if (
+              _namespacedOutput.errors &&
+              _namespacedOutput.errors.some(
+                (error: { severity: string }) => error.severity === "error"
+              )
+            ) {
+              setWizardStep(WizardStep.COMPILATION_ERROR);
+            } else {
+              setWizardStep(WizardStep.SELECT_CONTRACT);
+            }
+            worker.terminate();
+          },
+          false
+        );
+        worker.postMessage({
+          solcInput: JSON.stringify(_namespacedInput),
+          solcBin: compilerBinary,
+        });
+      } catch (error) {
+        const _solcOutput: SolcOutput = {
+          errors: [
+            {
+              severity: "error",
+              formattedMessage: "Error compiling namespaces: " + error,
+            },
+          ],
+          contracts: {},
+          sources: {},
+        };
+        setSolcOutput(_solcOutput);
+        setWizardStep(WizardStep.COMPILATION_ERROR);
+        return;
+      }
+    }
+  }, [
+    wizardStep,
+    solcOutput,
+    solcInput,
+    compilerBinary,
+    WizardStep.COMPILING_NAMESPACED,
+    WizardStep.COMPILATION_ERROR,
+    WizardStep.SELECT_CONTRACT,
+  ]);
 
   // Load storage layout function
   async function handleLoadStorageLayout() {

--- a/src/components/UploadWizardButton.tsx
+++ b/src/components/UploadWizardButton.tsx
@@ -582,7 +582,7 @@ export default function UploadWizardButton({
                 checked={advancedOptionsEnabled}
                 onChange={(e) => setAdvancedOptionsEnabled(e.target.checked)}
                 id="advanced-options-checkbox"
-                className="h-4 w-4 not-checked:appearance-none rounded border border-green-500 accent-green-500"
+                className="h-4 w-4 not-checked:appearance-none rounded border border-green-500 accent-green-500 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
               />
               <label
                 htmlFor="advanced-options-checkbox"
@@ -629,7 +629,7 @@ export default function UploadWizardButton({
                       checked={optimizationEnabled}
                       onChange={(e) => setOptimizationEnabled(e.target.checked)}
                       id="optimizer-checkbox"
-                      className="h-4 w-4 not-checked:appearance-none rounded border border-green-500 accent-green-500"
+                      className="h-4 w-4 not-checked:appearance-none rounded border border-green-500 accent-green-500 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
                     />
                     <label
                       htmlFor="optimizer-checkbox"
@@ -662,7 +662,7 @@ export default function UploadWizardButton({
                       checked={viaIREnabled}
                       onChange={(e) => setViaIREnabled(e.target.checked)}
                       id="via-ir-checkbox"
-                      className={`h-4 w-4 not-checked:appearance-none rounded border border-green-500 accent-green-500`}
+                      className={`h-4 w-4 not-checked:appearance-none rounded border border-green-500 accent-green-500 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]`}
                     />
                     <label
                       htmlFor="via-ir-checkbox"

--- a/src/components/UploadWizardButton.tsx
+++ b/src/components/UploadWizardButton.tsx
@@ -36,6 +36,12 @@ interface UploadWizardButtonProps {
   triggerVisualizerId?: number;
 }
 
+// viaIR management
+function isViaIRSupported(version: string) {
+  if (!version) return false;
+  return versions.compare(version, MIN_VIA_IR_VERSION, ">=");
+}
+
 export default function UploadWizardButton({
   setParentDialogOpen = undefined,
   triggerVisualizerId = undefined,
@@ -93,11 +99,6 @@ export default function UploadWizardButton({
     Record<string, string>
   >({});
 
-  // viaIR management
-  function isViaIRSupported(version: string) {
-    if (!compilerVersion) return false;
-    return versions.compare(version, MIN_VIA_IR_VERSION, ">=");
-  }
   useEffect(() => {
     if (!isViaIRSupported(compilerVersion)) {
       setViaIREnabled(false);
@@ -294,88 +295,99 @@ export default function UploadWizardButton({
   }
 
   // Compile Namespaces useEffect
-  async function compileNamespaces() {
-    try {
-      // To avoid FUNCTION_PAYLOAD_TOO_LARGE compress the  data using brotli
-      const _brotli = await brotliPromise;
-      const _textEncoder = new TextEncoder();
-      const _uncompressedBodyRequest = _textEncoder.encode(
-        JSON.stringify({
-          solcInput: solcInput,
-          solcOutput: solcOutput,
-          compilerVersion: compilerVersion,
-        })
-      );
-      const _compressedBodyRequest = _brotli.compress(
-        _uncompressedBodyRequest,
-        {
-          quality: BROTLI_QUALITY,
-        }
-      );
-
-      const response = await fetch("/api/get_namespaced_input", {
-        method: "POST",
-        headers: { "Content-Type": "application/octet-stream" },
-        body: new Uint8Array(_compressedBodyRequest),
-      });
-      if (!response.ok) {
-        throw new Error((await response.json()).message);
-      }
-
-      // Parse the response
-      const _arrayBuffer = await response.arrayBuffer();
-      const _textDecoder = new TextDecoder();
-      const _namespacedInput = JSON.parse(_textDecoder.decode(_arrayBuffer));
-
-      // Compile contract using compiler worker
-      const worker = new Worker("/dynSolcWorkerBundle.js");
-      worker.addEventListener(
-        "message",
-        (msg) => {
-          const _namespacedOutput: SolcOutput = JSON.parse(msg.data.solcOutput);
-          setNamespacedOutput(_namespacedOutput);
-          if (
-            _namespacedOutput.errors &&
-            _namespacedOutput.errors.some(
-              (error: { severity: string }) => error.severity === "error"
-            )
-          ) {
-            setWizardStep(WizardStep.COMPILATION_ERROR);
-          } else {
-            setWizardStep(WizardStep.SELECT_CONTRACT);
-          }
-          worker.terminate();
-        },
-        false
-      );
-      worker.postMessage({
-        solcInput: JSON.stringify(_namespacedInput),
-        solcBin: compilerVersions[compilerVersion],
-      });
-    } catch (error) {
-      const _solcOutput: SolcOutput = {
-        errors: [
-          {
-            severity: "error",
-            formattedMessage: "Error compiling namespaces: " + error,
-          },
-        ],
-        contracts: {},
-        sources: {},
-      };
-      setSolcOutput(_solcOutput);
-      setWizardStep(WizardStep.COMPILATION_ERROR);
-      return;
-    }
-  }
   useEffect(() => {
     if (
-      wizardStep === WizardStep.COMPILING_NAMESPACED &&
-      solcOutput !== undefined
+      wizardStep !== WizardStep.COMPILING_NAMESPACED ||
+      solcOutput === undefined
     ) {
-      compileNamespaces();
+      return;
     }
-  }, [wizardStep]);
+    compileNamespaces();
+
+    async function compileNamespaces() {
+      try {
+        // To avoid FUNCTION_PAYLOAD_TOO_LARGE compress the  data using brotli
+        const _brotli = await brotliPromise;
+        const _textEncoder = new TextEncoder();
+        const _uncompressedBodyRequest = _textEncoder.encode(
+          JSON.stringify({
+            solcInput: solcInput,
+            solcOutput: solcOutput,
+            compilerVersion: compilerVersion,
+          })
+        );
+        const _compressedBodyRequest = _brotli.compress(
+          _uncompressedBodyRequest,
+          {
+            quality: BROTLI_QUALITY,
+          }
+        );
+
+        const response = await fetch("/api/get_namespaced_input", {
+          method: "POST",
+          headers: { "Content-Type": "application/octet-stream" },
+          body: new Uint8Array(_compressedBodyRequest),
+        });
+        if (!response.ok) {
+          throw new Error((await response.json()).message);
+        }
+
+        // Parse the response
+        const _arrayBuffer = await response.arrayBuffer();
+        const _textDecoder = new TextDecoder();
+        const _namespacedInput = JSON.parse(_textDecoder.decode(_arrayBuffer));
+
+        // Compile contract using compiler worker
+        const worker = new Worker("/dynSolcWorkerBundle.js");
+        worker.addEventListener(
+          "message",
+          (msg) => {
+            const _namespacedOutput: SolcOutput = JSON.parse(msg.data.solcOutput);
+            setNamespacedOutput(_namespacedOutput);
+            if (
+              _namespacedOutput.errors &&
+              _namespacedOutput.errors.some(
+                (error: { severity: string }) => error.severity === "error"
+              )
+            ) {
+              setWizardStep(WizardStep.COMPILATION_ERROR);
+            } else {
+              setWizardStep(WizardStep.SELECT_CONTRACT);
+            }
+            worker.terminate();
+          },
+          false
+        );
+        worker.postMessage({
+          solcInput: JSON.stringify(_namespacedInput),
+          solcBin: compilerVersions[compilerVersion],
+        });
+      } catch (error) {
+        const _solcOutput: SolcOutput = {
+          errors: [
+            {
+              severity: "error",
+              formattedMessage: "Error compiling namespaces: " + error,
+            },
+          ],
+          contracts: {},
+          sources: {},
+        };
+        setSolcOutput(_solcOutput);
+        setWizardStep(WizardStep.COMPILATION_ERROR);
+        return;
+      }
+    }
+  }, [
+    wizardStep,
+    solcOutput,
+    solcInput,
+    compilerVersion,
+    compilerVersions,
+    WizardStep.COMPILING_NAMESPACED,
+    WizardStep.COMPILATION_ERROR,
+    WizardStep.SELECT_CONTRACT,
+  ]);
 
   // Load storage layout function
   async function handleLoadStorageLayout() {

--- a/src/components/UploadWizardButton.tsx
+++ b/src/components/UploadWizardButton.tsx
@@ -582,7 +582,7 @@ export default function UploadWizardButton({
                 checked={advancedOptionsEnabled}
                 onChange={(e) => setAdvancedOptionsEnabled(e.target.checked)}
                 id="advanced-options-checkbox"
-                className="h-4 w-4 not-checked:appearance-none rounded border border-green-500 accent-green-500 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                className="checkbox-green h-4 w-4 appearance-none rounded border border-green-500 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
               />
               <label
                 htmlFor="advanced-options-checkbox"
@@ -629,7 +629,7 @@ export default function UploadWizardButton({
                       checked={optimizationEnabled}
                       onChange={(e) => setOptimizationEnabled(e.target.checked)}
                       id="optimizer-checkbox"
-                      className="h-4 w-4 not-checked:appearance-none rounded border border-green-500 accent-green-500 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                      className="checkbox-green h-4 w-4 appearance-none rounded border border-green-500 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
                     />
                     <label
                       htmlFor="optimizer-checkbox"
@@ -662,7 +662,7 @@ export default function UploadWizardButton({
                       checked={viaIREnabled}
                       onChange={(e) => setViaIREnabled(e.target.checked)}
                       id="via-ir-checkbox"
-                      className={`h-4 w-4 not-checked:appearance-none rounded border border-green-500 accent-green-500 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]`}
+                      className={`checkbox-green h-4 w-4 appearance-none rounded border border-green-500 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]`}
                     />
                     <label
                       htmlFor="via-ir-checkbox"

--- a/src/index.css
+++ b/src/index.css
@@ -26,7 +26,7 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.72 0.219 149.579); /* #00c951, matches --foreground */
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -39,7 +39,7 @@
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-ring: oklch(0.72 0.219 149.579);
 }
 
 .dark {
@@ -60,7 +60,7 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.72 0.219 149.579);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
@@ -73,7 +73,7 @@
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-ring: oklch(0.72 0.219 149.579);
 }
 
 @theme inline {

--- a/src/index.css
+++ b/src/index.css
@@ -123,6 +123,15 @@
   }
 }
 
+  /* Checked state for themed appearance-none checkboxes, so the shape stays rounded in all states */
+.checkbox-green:checked {
+  background-color: #22c55e; /* green-500 */
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%23021005' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.707 4.793a1 1 0 0 1 0 1.414l-5.5 5.5a1 1 0 0 1-1.414 0l-2.5-2.5a1 1 0 1 1 1.414-1.414L6.5 9.586l4.793-4.793a1 1 0 0 1 1.414 0z'/%3e%3c/svg%3e");
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
   /* Class used to customize scrollbar for Firefox */
 .minimal-h-scrollbar-green {
   scrollbar-width: thin; /* Makes the scrollbar thin */


### PR DESCRIPTION
Fixes #100

## Problem

- Focusing the "Network" combobox, the compiler-version/network `SelectTrigger`s, or the native checkboxes ("Advanced Compiler Options", "Optimization", "via-IR") showed a neutral-gray focus ring/outline that clashed with the green-on-black terminal theme (see issue screenshots).
- The checkboxes also changed shape between states: rounded while unchecked, square once checked.

## Root cause

- The shadcn scaffold in `src/index.css` left `--ring` at its default gray (`oklch(0.708 0 0)`). All shadcn primitives (`Button`, `SelectTrigger`, `Tabs`, and the global `outline-ring/50` base rule) derive their `focus-visible` ring color from that variable.
- The native `<input type="checkbox">` elements in `UploadWizardButton.tsx` had no focus styling at all, so the browser drew its default gray outline.
- `not-checked:appearance-none` meant checkboxes were custom-drawn (rounded) while unchecked but flipped to native square rendering once checked.

## Fix

- Set `--ring` (and `--sidebar-ring`, plus the unused `.dark` block for consistency) to the theme green `oklch(0.72 0.219 149.579)` — the same value as `--foreground` (#00c951). Every focus ring in the app now follows the theme.
- Gave the three native checkboxes the same `focus-visible:ring-ring/50` treatment as the shadcn primitives.
- Made checkboxes `appearance-none` in all states and drew the checked state with a `.checkbox-green` helper (green fill + inline SVG check), so the rounded shape is stable across unchecked/checked/focus/hover.

## Bonus: lint is now clean (0 warnings)

Resolved the three pre-existing `react-hooks/exhaustive-deps` warnings:

- `isViaIRSupported` only depends on the version argument it receives, so it is hoisted to module scope; the via-IR reset effect's `[compilerVersion]` deps are now complete.
- `compileNamespaces` (only ever called from its trigger effect) moved inside the `useEffect` in both wizards with the full dependency list. This is behavior-preserving: every code path that changes those deps also leaves `COMPILING_NAMESPACED` in the same batched React update, so the namespaced compile still fires exactly once per entry into the step.

## Verification

Drove the app headless with Playwright (keyboard navigation triggers `focus-visible`):

- Upload dialog → compiler-version select trigger: green 3px ring at 50% opacity, green border ✅
- Analyze dialog → network combobox button: same green ring ✅
- "Advanced Compiler Options" checkbox: green rounded ring when keyboard-focused, both unchecked and checked; `border-radius: 4px` and `appearance: none` in every state ✅
- via-IR logic: appears on 0.8.35, hidden on 0.8.0, reappears **unchecked** after switching back (reset effect fires) ✅
- Full compile flow end-to-end (real `/api`, real solc wasm): uploaded an ERC-7201 contract on 0.8.35 → compiled → namespaced compile → contract selection → storage layout rendered with both "Root layout" and "erc7201:example.main" tabs ✅
- `/api/get_namespaced_input` was called **exactly once** for the whole flow — the new dependency list does not re-trigger compilation ✅
- `yarn build` passes; `yarn lint` exits clean with **0 warnings** ✅

Not driven: the Analyze (Sourcify) wizard's compile flow — its `compileNamespaces` change is structurally identical to the Upload wizard's verified one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)