### PR TITLE
fix: return 404 instead of 500 for uncached storage layout lookups

### DIFF
--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -19,7 +19,7 @@ export async function POST(request) {
     const cacheKey = `${chainId}:${address}`;
     const entry = await redis.get(cacheKey);
 
-    if (!entry.storageLayout) {
+    if (!entry?.storageLayout) {
       return new Response(
         JSON.stringify({ message: "Storage layout not cached." }),
         {


### PR DESCRIPTION
## Summary

- `redis.get()` resolves to `null` when a key was never cached — the common case for a first-time `?chainId=&address=` share-link lookup. `entry.storageLayout` then threw a `TypeError`, so `api/get_cached_storage_layout` returned `500 {"message":"Cannot read properties of null (reading 'storageLayout')"}` and its intended 404 "Storage layout not cached." branch was unreachable. This affects production today for any share link to a not-yet-cached contract.
- One-character fix: `entry.storageLayout` → `entry?.storageLayout`.

Cherry-picked from #95 (commit `e8da6fd`, authored by @Ynyesto — authorship preserved) so this production bug fix can land independently of the larger share-link fallback discussion happening there.

## Test plan

Verified against a real `yarn vercel dev` session on this branch, with project credentials:

- [x] Uncached contract (`1:0x6B17…1d0F`) → `404 {"message":"Storage layout not cached."}` — previously `500`
- [x] Cached contract (`1:0x1f98…F984`) → `200` with the stored layout (unchanged)
- [x] Missing params → `400 {"message":"Chain ID and address are required."}` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)