### PR TITLE
💅 style: apply red error styling to non verified contract error tab

### DIFF
--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -235,7 +235,7 @@ export default function AnalyzeWizardButton({
               href="https://verify.sourcify.dev/"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-green-500 underline"
+              className="text-red-500 underline"
             >
               Sourcify Verifier
             </a>
@@ -718,20 +718,20 @@ export default function AnalyzeWizardButton({
 
       {/* Wizard Step 5: Fetching from Sourcify Errors */}
       {wizardStep === WizardStep.FETCHING_ERROR && (
-        <DialogContent className="bg-black border-green-500 p-6 rounded-md">
+        <DialogContent className="bg-black border-red-500 text-red-500 p-6 rounded-md [&>button]:text-red-500 [&>button:hover]:text-red-500 [&>button:hover]:bg-red-900/30">
           <DialogHeader>
-            <DialogTitle className="text-green-500">
+            <DialogTitle className="text-red-500 text-center font-bold">
               Errors while fetching the contract artifacts from Sourcify
             </DialogTitle>
             <DialogDescription
               id="upload-dialog-description"
-              className="text-green-800"
+              className="text-red-500 text-center"
             >
-              <span className="text-red-500">{fetchArtifactsError}</span>
+              {fetchArtifactsError}
             </DialogDescription>
           </DialogHeader>
           <div className="flex items-center justify-center">
-            <FileX className="h-15 w-15 text-green-500 my-4" />
+            <FileX className="h-15 w-15 text-red-500 my-4" />
           </div>
         </DialogContent>
       )}


### PR DESCRIPTION
## Summary

Restyles the "Errors while fetching the contract artifacts from Sourcify" dialog in the analyze wizard to use the same red error styling as the share-link not-found dialog:

- Red border and red centered bold title (was green)
- Centered red description text
- Red `FileX` icon and red close (X) button
- "Sourcify Verifier" link in red instead of green, so it doesn't clash inside the red dialog

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)