### PR TITLE
feat: unwrap struct fields in the storage visualizer

### DIFF
--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -174,11 +174,7 @@ export default function StorageVisualizer({
     isNamespace: boolean = false
   ): StorageLayoutWrapper {
     // Unwrap struct fields so they display individually instead of as one
-    // opaque blob spanning the struct's full size. Must run before the
-    // baseSlot normalization below: struct members' slots (from
-    // storageLayout.types) are always decimal, while normalization
-    // rewrites .slot to an unprefixed hex string, which BigInt() can't
-    // parse back consistently.
+    // opaque blob spanning the struct's full size.
     storageItems = unwrapStructItems(storageItems, storageLayout.types);
 
     // Normalize baseSlot if is custom
@@ -188,7 +184,7 @@ export default function StorageVisualizer({
         storageItemsNormalized[i].slot = (
           BigInt(normalizeUint256Literal(storageItemsNormalized[i].slot)) -
           BigInt(baseSlot)
-        ).toString(16);
+        ).toString();
       }
       storageItems = storageItemsNormalized;
     }

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -25,10 +25,52 @@ import { normalizeUint256Literal } from "@/lib/integer-literals";
 import { erc7201 } from "@/lib/erc7201";
 import { MAX_CONTIGUOUS_ITEM_SLOT_ROWS } from "@/lib/constants";
 
-import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
+import type {
+  StorageLayout,
+  StorageItem,
+  TypeItem,
+  TypeItemMembers,
+  StructMember,
+} from "@openzeppelin/upgrades-core";
 
 const SLOT_ZERO =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+// A type's `members` is either struct fields or enum value names (plain
+// strings) - only the former has its own slot/offset layout to unwrap.
+function isStructMembers(members: TypeItemMembers): members is StructMember[] {
+  return members.length === 0 || typeof members[0] !== "string";
+}
+
+// Replaces struct-typed items with one synthetic item per field (dot-joined
+// label, e.g. "testStorage.a") so struct internals display the same way as
+// top-level variables instead of one opaque blob. Recurses for nested
+// structs. Arrays of structs and mappings are left as-is: their members
+// don't have static slots to unwrap this way.
+function unwrapStructItems(
+  items: StorageItem[],
+  types: Record<string, TypeItem>
+): StorageItem[] {
+  const result: StorageItem[] = [];
+  for (const item of items) {
+    const members = types[item.type]?.members;
+    if (members && isStructMembers(members)) {
+      const fieldItems: StorageItem[] = members.map((member) => ({
+        astId: item.astId,
+        contract: item.contract,
+        label: `${item.label}.${member.label}`,
+        type: member.type,
+        src: item.src,
+        offset: member.offset,
+        slot: (BigInt(item.slot ?? 0) + BigInt(member.slot ?? 0)).toString(),
+      }));
+      result.push(...unwrapStructItems(fieldItems, types));
+    } else {
+      result.push(item);
+    }
+  }
+  return result;
+}
 
 export interface StorageVisualizerProps {
   contractName: string;
@@ -131,6 +173,14 @@ export default function StorageVisualizer({
     baseSlot: string,
     isNamespace: boolean = false
   ): StorageLayoutWrapper {
+    // Unwrap struct fields so they display individually instead of as one
+    // opaque blob spanning the struct's full size. Must run before the
+    // baseSlot normalization below: struct members' slots (from
+    // storageLayout.types) are always decimal, while normalization
+    // rewrites .slot to an unprefixed hex string, which BigInt() can't
+    // parse back consistently.
+    storageItems = unwrapStructItems(storageItems, storageLayout.types);
+
     // Normalize baseSlot if is custom
     if (!isNamespace && baseSlot !== SLOT_ZERO) {
       const storageItemsNormalized = JSON.parse(JSON.stringify(storageItems));


### PR DESCRIPTION
A struct-typed storage item (e.g. a TestStorage struct with bool, address, uint40, bytes32 fields) rendered as one opaque blob spanning the struct's full size, with a single generic "struct X | label" tooltip - the individual fields and their exact byte ranges weren't visible.

Adds unwrapStructItems(), which replaces a struct item with one synthetic item per field before the existing slot-building logic runs, using dot-joined labels (e.g. "testStorage.a") and slot arithmetic (struct member slots are relative to the struct's own start per solc's storageLayout format, so absolute slot = struct's slot + member's slot). Recurses for nested structs. Arrays of structs and mappings are intentionally left as-is - their members don't have static slots to unwrap this way.

Verified end-to-end via file upload for both the exact contract from the issue (TestStorage: bool/address/uint40/bytes32, correctly split across 2 slots with correct widths/offsets/tooltips) and a nested-struct case (outer.flag / outer.inner.x / outer.inner.y / outer.z, matching Solidity's actual packing rules - nested struct members always start a new slot). Regression-checked against the #55/#56 TokenApprove example: unaffected, still 102 rows.

Fixes GianfrancoBazzani/evm-storage.codes#66