### PR TITLE
Replace Openfort EIP-7702 landing example with PufferVaultV5

### DIFF
--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -28,9 +28,9 @@ export default function Landing({ notice }: { notice?: ReactNode }) {
       chainId: "1",
     },
     {
-      name: "Openfort EIP-7702",
-      address: "0x9C5b2765fe0aC3f0566CD6B1c96c0cCD393EE49c",
-      chainId: "84532",
+      name: "PufferVaultV5",
+      address: "0x3b2fdFdEFE919dBcCE0bc5ac426097d5523B8AFA",
+      chainId: "1",
     },
     {
       name: "MorphoToken",


### PR DESCRIPTION
## Summary
- Replace the "Openfort EIP-7702" example (`0x9C5b2765fe0aC3f0566CD6B1c96c0cCD393EE49c`, Base Sepolia / chain ID 84532) on the landing page with "PufferVaultV5" (`0x3b2fdFdEFE919dBcCE0bc5ac426097d5523B8AFA`, Ethereum mainnet / chain ID 1).

## Verification
- `yarn build` (tsc type-check + Vite build) and `yarn lint` pass.
- The contract is verified on Sourcify for chain 1 with `exact_match` — checked via the same `server/v2/contract` endpoint the analyze flow uses, so the example link resolves.
- EIP-55 checksum of the new address validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)