### PR TITLE
fix: guide the user to the analyze wizard when a share link isn't cached

### DIFF
--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState, useEffect } from "react";
 import { StorageLayoutsContext } from "@/contexts/StorageLayoutsContext";
-import { Upload, Loader2, FileX, ChevronsUpDown, Check } from "lucide-react";
+import { Search, Loader2, FileX, ChevronsUpDown, Check } from "lucide-react";
 import {
   Dialog,
   DialogTrigger,
@@ -595,7 +595,7 @@ export default function AnalyzeWizardButton({
           )}
           onClick={() => setDialogOpen(true)}
         >
-          <Upload className="mr-2 h-4 w-4" /> {triggerLabel}
+          <Search className="mr-2 h-4 w-4" /> {triggerLabel}
         </Button>
       </DialogTrigger>
 

--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -60,6 +60,7 @@ interface AnalyzeWizardButtonProps {
   initialChainId?: number;
   initialAddress?: string;
   triggerLabel?: string;
+  triggerClassName?: string;
 }
 
 export default function AnalyzeWizardButton({
@@ -68,6 +69,7 @@ export default function AnalyzeWizardButton({
   initialChainId = undefined,
   initialAddress = undefined,
   triggerLabel = "ANALYZE ADDRESS",
+  triggerClassName,
 }: AnalyzeWizardButtonProps) {
   // Global context
   const storageLayoutsContext = useContext(StorageLayoutsContext);
@@ -587,7 +589,10 @@ export default function AnalyzeWizardButton({
     <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
       <DialogTrigger asChild>
         <Button
-          className="w-52 bg-green-900/30 text-green-500 border border-green-500 hover:bg-green-600/40 hover:text-green-300 transition-all duration-300 px-8 py-6 text-lg animate-pulse"
+          className={cn(
+            "w-52 bg-green-900/30 text-green-500 border border-green-500 hover:bg-green-600/40 hover:text-green-300 transition-all duration-300 px-8 py-6 text-lg animate-pulse",
+            triggerClassName
+          )}
           onClick={() => setDialogOpen(true)}
         >
           <Upload className="mr-2 h-4 w-4" /> {triggerLabel}

--- a/src/components/ShareLinkNotFound.tsx
+++ b/src/components/ShareLinkNotFound.tsx
@@ -5,6 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import AnalyzeWizardButton from "@/components/AnalyzeWizardButton";
 
 export type ShareLinkMissKind = "not-cached" | "error" | "invalid";
 
@@ -31,6 +32,12 @@ export default function ShareLinkNotFound({
         ? "ERROR — STORAGE LAYOUT NOT FOUND"
         : "ERROR — INVALID SHARE LINK";
 
+  // A valid chainId/address just means this specific contract hasn't been
+  // compiled and cached before - the user can still generate its layout
+  // themselves via the normal wizard, pre-filled so they don't have to
+  // re-type the address. An "invalid" link has nothing valid to pre-fill.
+  const canGenerate = kind !== "invalid";
+
   return (
     <Dialog open onOpenChange={(open) => !open && onDismiss()}>
       <DialogContent className="bg-black border-red-500 text-red-500 p-6 [&>button]:text-red-500 [&>button:hover]:text-red-500 [&>button:hover]:bg-red-900/30">
@@ -48,6 +55,15 @@ export default function ShareLinkNotFound({
                 : "Storage layout not found."}
           </DialogDescription>
         </DialogHeader>
+        {canGenerate && (
+          <div className="flex justify-center [&_button]:border-red-500 [&_button]:text-red-500 [&_button:hover]:bg-red-900/30 [&_button:hover]:text-red-500">
+            <AnalyzeWizardButton
+              initialChainId={Number(chainId)}
+              initialAddress={address}
+              triggerLabel="Generate this storage layout"
+            />
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/ShareLinkNotFound.tsx
+++ b/src/components/ShareLinkNotFound.tsx
@@ -56,11 +56,12 @@ export default function ShareLinkNotFound({
           </DialogDescription>
         </DialogHeader>
         {canGenerate && (
-          <div className="flex justify-center [&_button]:border-red-500 [&_button]:text-red-500 [&_button:hover]:bg-red-900/30 [&_button:hover]:text-red-500">
+          <div className="flex justify-center">
             <AnalyzeWizardButton
               initialChainId={Number(chainId)}
               initialAddress={address}
               triggerLabel="Generate this storage layout"
+              triggerClassName="w-auto max-w-full animate-none whitespace-normal px-5 py-4 text-base leading-tight"
             />
           </div>
         )}


### PR DESCRIPTION
## Summary
- Reported for [`?address=0x1F98431c8aD98523631AE4a59f267346ea31F984&chainId=10`](https://evm-storage.codes/?address=0x1F98431c8aD98523631AE4a59f267346ea31F984&chainId=10) (the originally-linked example no longer errors, so I used this one to reproduce): a `?chainId=&address=` link that isn't cached shows a dead-end "storage layout not found" banner with no way to proceed except retyping the address into a fresh `ANALYZE ADDRESS` flow from scratch.
- `AnalyzeWizardButton` already had `initialChainId`/`initialAddress`/`triggerLabel` props for exactly this pre-fill use case, but they were never actually wired up anywhere in the codebase. `ShareLinkNotFound` now renders it inline for the `not-cached`/`error` miss kinds (not `invalid`, which has no valid address/chain to pre-fill), labeled "Generate this storage layout".
- One deliberate design note: this does **not** auto-dismiss the not-found banner when the wizard opens. Nesting `AnalyzeWizardButton` inside `ShareLinkNotFound`'s own dialog means calling `onDismiss` in the same click handler unmounts the parent (and therefore the child, along with its just-opened dialog state) before it ever renders — React batches both state updates into one commit, so the child never gets a chance to show its dialog. Leaving the banner mounted lets the second dialog stack cleanly on top instead (Radix's own overlay naturally covers the first one), which also reads fine if the user cancels back out — the original error is still there to try again.

Fixes #111

## Test plan
- [x] `yarn build` clean; no new lint issues.
- [x] End-to-end verified via Playwright against a running `yarn vercel dev` with the exact reported link: clicking "Generate this storage layout" opens the wizard with **OP Mainnet (Chain Id: 10)** and the address already filled in, ready to fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)