### PR TITLE
feat: add EIP-1967 proxy support

### DIFF
--- a/api/_lib/eip1967.js
+++ b/api/_lib/eip1967.js
@@ -8,6 +8,13 @@ import {
 } from "@openzeppelin/upgrades-core";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+// keccak256("eip1967.proxy.implementation") - 1. upgrades-core's
+// getImplementationAddress also falls back to the pre-EIP-1967 ZeppelinOS
+// slot (keccak256("org.zeppelinos.proxy.implementation")), so when it
+// resolves an implementation we read this slot directly to tell the two
+// kinds apart (e.g. USDC is a legacy zos proxy, not EIP-1967).
+const EIP1967_IMPLEMENTATION_SLOT =
+  "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
 const RPC_TIMEOUT_MS = 4_000;
 // Detection makes up to three RPC calls (implementation, beacon, admin) and
 // each call retries every candidate URL, so keep the list short enough that a
@@ -53,17 +60,39 @@ export async function getEip1967ProxyInfo(chainId, address) {
     return { isProxy: false };
   }
 
+  let kind = beaconAddress ? "beacon" : "eip1967";
+  if (
+    directImplementationAddress &&
+    !(await isEip1967ImplementationSlotSet(provider, address))
+  ) {
+    kind = "legacy";
+  }
+
   const adminAddress = await getOptionalAdminAddress(provider, address);
   return {
     isProxy: true,
     proxyInfo: {
-      kind: beaconAddress ? "beacon" : "eip1967",
+      kind,
       proxyAddress: address,
       implementationAddress,
       ...(adminAddress ? { adminAddress } : {}),
       ...(beaconAddress ? { beaconAddress } : {}),
     },
   };
+}
+
+async function isEip1967ImplementationSlotSet(provider, address) {
+  try {
+    const rawSlot = await provider.send("eth_getStorageAt", [
+      address,
+      EIP1967_IMPLEMENTATION_SLOT,
+      "latest",
+    ]);
+    return Boolean(rawSlot) && BigInt(rawSlot) !== 0n;
+  } catch {
+    // Can't tell the kinds apart - keep the default EIP-1967 label.
+    return true;
+  }
 }
 
 export function isAddress(value) {

--- a/api/_lib/eip1967.js
+++ b/api/_lib/eip1967.js
@@ -1,0 +1,203 @@
+import {
+  EIP1967BeaconNotFound,
+  EIP1967ImplementationNotFound,
+  getAdminAddress,
+  getBeaconAddress,
+  getImplementationAddress,
+  getImplementationAddressFromBeacon,
+} from "@openzeppelin/upgrades-core";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const RPC_TIMEOUT_MS = 4_000;
+// Detection makes up to three RPC calls (implementation, beacon, admin) and
+// each call retries every candidate URL, so keep the list short enough that a
+// chain full of dead RPCs can't run past the serverless function timeout.
+const MAX_RPC_URLS = 5;
+const FALLBACK_RPC_URLS = {
+  1: [
+    "https://ethereum-rpc.publicnode.com",
+    "https://rpc.flashbots.net",
+    "https://eth.merkle.io",
+  ],
+  10: ["https://mainnet.optimism.io"],
+  56: ["https://bsc-dataseed.binance.org"],
+  137: ["https://polygon-rpc.com"],
+  8453: ["https://mainnet.base.org"],
+  42161: ["https://arb1.arbitrum.io/rpc"],
+  43114: ["https://api.avax.network/ext/bc/C/rpc"],
+  11155111: ["https://ethereum-sepolia-rpc.publicnode.com"],
+};
+
+export async function getEip1967ProxyInfo(chainId, address) {
+  const rpcUrls = await getRpcUrls(chainId);
+  if (rpcUrls.length === 0) {
+    throw new Error(`No public HTTPS RPC URL found for chain ID ${chainId}.`);
+  }
+
+  const provider = createFallbackProvider(rpcUrls);
+  const directImplementationAddress = await getOptionalImplementationAddress(
+    provider,
+    address
+  );
+  const beaconAddress = directImplementationAddress
+    ? undefined
+    : await getOptionalBeaconAddress(provider, address);
+  const beaconImplementationAddress = beaconAddress
+    ? await getImplementationAddressFromBeacon(provider, beaconAddress)
+    : undefined;
+
+  const implementationAddress =
+    directImplementationAddress ?? beaconImplementationAddress;
+
+  if (!implementationAddress) {
+    return { isProxy: false };
+  }
+
+  const adminAddress = await getOptionalAdminAddress(provider, address);
+  return {
+    isProxy: true,
+    proxyInfo: {
+      kind: beaconAddress ? "beacon" : "eip1967",
+      proxyAddress: address,
+      implementationAddress,
+      ...(adminAddress ? { adminAddress } : {}),
+      ...(beaconAddress ? { beaconAddress } : {}),
+    },
+  };
+}
+
+export function isAddress(value) {
+  return /^0x[0-9a-fA-F]{40}$/.test(value);
+}
+
+export function sameAddress(left, right) {
+  return left?.toLowerCase() === right?.toLowerCase();
+}
+
+async function getRpcUrls(chainId) {
+  const fallbackUrls = FALLBACK_RPC_URLS[chainId] ?? [];
+  try {
+    const response = await fetch("https://sourcify.dev/server/chains", {
+      signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error("Failed to fetch Sourcify chain metadata.");
+    }
+
+    const chains = await response.json();
+    const chain = chains.find((candidate) => candidate.chainId === chainId);
+    if (!chain && fallbackUrls.length === 0) {
+      throw new Error(`Chain ID ${chainId} is not listed by Sourcify.`);
+    }
+
+    return [
+      ...fallbackUrls,
+      ...(chain?.rpc ?? []),
+      ...(chain?.traceSupportedRPCs ?? []),
+    ]
+      .filter(isUsableRpcUrl)
+      .filter((url, index, urls) => urls.indexOf(url) === index)
+      .slice(0, MAX_RPC_URLS);
+  } catch (error) {
+    if (fallbackUrls.length > 0) {
+      return fallbackUrls;
+    }
+    throw error;
+  }
+}
+
+function isUsableRpcUrl(url) {
+  return (
+    typeof url === "string" &&
+    url.startsWith("https://") &&
+    !url.includes("${") &&
+    !url.includes("{") &&
+    !url.includes("}") &&
+    !url.includes("localhost") &&
+    !url.includes("127.0.0.1")
+  );
+}
+
+function createFallbackProvider(rpcUrls) {
+  let preferredRpcUrl;
+  return {
+    async send(method, params) {
+      const errors = [];
+      const orderedRpcUrls = preferredRpcUrl
+        ? [preferredRpcUrl, ...rpcUrls.filter((url) => url !== preferredRpcUrl)]
+        : rpcUrls;
+      for (const rpcUrl of orderedRpcUrls) {
+        try {
+          const result = await sendRpc(rpcUrl, method, params);
+          preferredRpcUrl = rpcUrl;
+          return result;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : error;
+          errors.push(`${rpcUrl}: ${message}`);
+        }
+      }
+      throw new Error(
+        `All RPC URLs failed for ${method}: ${errors.join(" | ")}`
+      );
+    },
+  };
+}
+
+async function sendRpc(rpcUrl, method, params) {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      params,
+    }),
+    signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.message ?? "RPC error");
+  }
+  return payload.result;
+}
+
+async function getOptionalImplementationAddress(provider, address) {
+  try {
+    return await getImplementationAddress(provider, address);
+  } catch (error) {
+    if (error instanceof EIP1967ImplementationNotFound) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function getOptionalBeaconAddress(provider, address) {
+  try {
+    return await getBeaconAddress(provider, address);
+  } catch (error) {
+    if (error instanceof EIP1967BeaconNotFound) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function getOptionalAdminAddress(provider, address) {
+  // The admin address is informational only - a failure reading it must not
+  // discard an already-successful implementation detection.
+  try {
+    const adminAddress = await getAdminAddress(provider, address);
+    return adminAddress.toLowerCase() === ZERO_ADDRESS
+      ? undefined
+      : adminAddress;
+  } catch {
+    return undefined;
+  }
+}

--- a/api/extract_storage_layout.js
+++ b/api/extract_storage_layout.js
@@ -5,6 +5,7 @@ import {
 import { brotliDecompressSync } from "zlib";
 import { findAll, astDereferencer, isNodeType } from "solidity-ast/utils.js";
 import { Redis } from "@upstash/redis";
+import { getEip1967ProxyInfo, sameAddress } from "./_lib/eip1967.js";
 
 export async function POST(request) {
   try {
@@ -23,6 +24,7 @@ export async function POST(request) {
     const contractName = decompressedDataJson.contractName;
     const chainId = decompressedDataJson.chainId;
     const address = decompressedDataJson.address;
+    const sourceAddress = decompressedDataJson.sourceAddress;
 
     // Build decodeSrc function
     const decodeSrc = solcInputOutputDecoder(solcInput, solcOutput);
@@ -53,12 +55,35 @@ export async function POST(request) {
       getNamespacedCompilationContext(sourceName, contractDef, namespacedOutput)
     );
 
-    // Cache the storage layout in the database if it is not already cached
+    // Cache the storage layout in the database if it is not already cached.
     if (chainId && address) {
       try {
+        let integrityAddress = address;
+        let cacheProxyInfo = undefined;
+        if (sourceAddress && !sameAddress(sourceAddress, address)) {
+          const proxyResolution = await getEip1967ProxyInfo(
+            Number(chainId),
+            address
+          );
+          if (
+            !proxyResolution.proxyInfo ||
+            !sameAddress(
+              proxyResolution.proxyInfo.implementationAddress,
+              sourceAddress
+            )
+          ) {
+            console.warn(
+              "Proxy implementation does not match provided sourceAddress; storage layout wont be cached"
+            );
+            throw new Error("");
+          }
+          integrityAddress = sourceAddress;
+          cacheProxyInfo = proxyResolution.proxyInfo;
+        }
+
         // Minimal integrity test
         const response = await fetch(
-          `https://sourcify.dev/server/v2/contract/${chainId}/${address}?fields=stdJsonInput,compilation`,
+          `https://sourcify.dev/server/v2/contract/${chainId}/${integrityAddress}?fields=stdJsonInput,compilation`,
           {
             method: "GET",
           }
@@ -92,6 +117,11 @@ export async function POST(request) {
         await redis.set(cacheKey, {
           storageLayout: storageLayout,
           contractName: contractName,
+          sourceAddress:
+            sourceAddress && !sameAddress(sourceAddress, address)
+              ? sourceAddress
+              : undefined,
+          proxyInfo: cacheProxyInfo,
         });
         //await redis.set(cacheKey, storageLayout, {
         //  nx: true, // only store if not already exists

--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -35,6 +35,8 @@ export async function POST(request) {
       JSON.stringify({
         storageLayout: entry.storageLayout,
         contractName: entry.contractName,
+        sourceAddress: entry.sourceAddress,
+        proxyInfo: entry.proxyInfo,
       }),
       {
         status: 200,

--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -1,17 +1,19 @@
 import { Redis } from "@upstash/redis";
+import {
+  getEip1967ProxyInfo,
+  isAddress,
+  sameAddress,
+} from "./_lib/eip1967.js";
 
 export async function POST(request) {
   try {
     const { chainId, address } = await request.json();
 
     if (!chainId || !address) {
-      return new Response(
-        JSON.stringify({ message: "Chain ID and address are required." }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        }
-      );
+      return jsonResponse({ message: "Chain ID and address are required." }, 400);
+    }
+    if (!/^\d+$/.test(String(chainId)) || !isAddress(address)) {
+      return jsonResponse({ message: "Invalid chain ID or address." }, 400);
     }
 
     // Cache the storage layout in Redis
@@ -20,39 +22,66 @@ export async function POST(request) {
     const entry = await redis.get(cacheKey);
 
     if (!entry?.storageLayout) {
-      return new Response(
-        JSON.stringify({ message: "Storage layout not cached." }),
-        {
-          status: 404,
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
-      );
+      return cacheMissResponse();
     }
 
-    return new Response(
-      JSON.stringify({
+    // Proxies can be upgraded after their layout was cached, which would
+    // leave us serving the old implementation's layout forever. Re-resolve
+    // the proxy and treat a changed implementation as a cache miss so the
+    // wizard regenerates (and re-caches) the current one. If the check
+    // itself fails (RPCs down), serve the possibly-stale entry rather than
+    // breaking the share link.
+    if (entry.proxyInfo?.implementationAddress) {
+      try {
+        const proxyResolution = await getEip1967ProxyInfo(
+          Number(chainId),
+          address
+        );
+        if (
+          !proxyResolution.proxyInfo ||
+          !sameAddress(
+            proxyResolution.proxyInfo.implementationAddress,
+            entry.proxyInfo.implementationAddress
+          )
+        ) {
+          return cacheMissResponse("Cached proxy implementation is outdated.");
+        }
+      } catch (error) {
+        console.warn(
+          "Proxy staleness check failed, serving cached layout:",
+          error
+        );
+      }
+    }
+
+    return jsonResponse(
+      {
         storageLayout: entry.storageLayout,
         contractName: entry.contractName,
         sourceAddress: entry.sourceAddress,
         proxyInfo: entry.proxyInfo,
-      }),
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          "Cache-Control": "s-maxage=86400, stale-while-revalidate",
-        },
-      }
+      },
+      200,
+      entry.proxyInfo ? "no-store" : "s-maxage=86400, stale-while-revalidate"
     );
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
     console.error(errorMessage);
-    return new Response(JSON.stringify({ message: errorMessage }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ message: errorMessage }, 500);
   }
+}
+
+function cacheMissResponse(message = "Storage layout not cached.") {
+  return jsonResponse({ message }, 404);
+}
+
+function jsonResponse(body, status = 200, cacheControl = undefined) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...(cacheControl ? { "Cache-Control": cacheControl } : {}),
+    },
+  });
 }

--- a/api/get_eip1967_proxy_info.js
+++ b/api/get_eip1967_proxy_info.js
@@ -1,0 +1,39 @@
+import {
+  getEip1967ProxyInfo,
+  isAddress,
+} from "./_lib/eip1967.js";
+
+export async function POST(request) {
+  try {
+    const { chainId, address } = await request.json();
+
+    if (!chainId || !address) {
+      return jsonResponse(
+        { message: "Chain ID and address are required." },
+        400
+      );
+    }
+    if (!/^\d+$/.test(String(chainId)) || !isAddress(address)) {
+      return jsonResponse({ message: "Invalid chain ID or address." }, 400);
+    }
+
+    return jsonResponse(
+      await getEip1967ProxyInfo(Number(chainId), address)
+    );
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    console.error(errorMessage);
+    return jsonResponse({ message: errorMessage }, 500);
+  }
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "s-maxage=300, stale-while-revalidate",
+    },
+  });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,8 @@ function App() {
               storageLayout: data.storageLayout,
               chainId: Number(chainId),
               address: address ? address : undefined,
+              sourceAddress: data.sourceAddress,
+              proxyInfo: data.proxyInfo,
             },
           ]);
         } else {
@@ -130,6 +132,8 @@ function App() {
                     id={storageLayout.id}
                     chainId={storageLayout.chainId}
                     address={storageLayout.address}
+                    sourceAddress={storageLayout.sourceAddress}
+                    proxyInfo={storageLayout.proxyInfo}
                   />
                 ))}
               </div>

--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -249,7 +249,15 @@ export default function AnalyzeWizardButton({
       return;
     }
 
-    const detectedProxyInfo = await fetchEip1967ProxyInfo(chainId, address);
+    // Proxy detection is a convenience: if it fails (no public RPC for the
+    // chain, RPCs down, ...) fall back to analyzing the address as-is
+    // rather than blocking the whole flow.
+    let detectedProxyInfo: Eip1967ProxyInfo | undefined;
+    try {
+      detectedProxyInfo = await fetchEip1967ProxyInfo(chainId, address);
+    } catch (error) {
+      console.warn("EIP-1967 proxy detection failed:", error);
+    }
     const sourcifyAddress = detectedProxyInfo?.implementationAddress ?? address;
     setProxyInfo(detectedProxyInfo);
     setSourceAddress(sourcifyAddress);
@@ -625,27 +633,20 @@ export default function AnalyzeWizardButton({
     chainId: number,
     address: string
   ): Promise<Eip1967ProxyInfo | undefined> {
-    try {
-      const response = await fetch("/api/get_eip1967_proxy_info", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ chainId, address }),
-      });
-      if (!response.ok) {
-        console.warn(
-          "EIP-1967 proxy detection failed:",
-          (await response.json()).message
-        );
-        return undefined;
-      }
-
-      const proxyInfoResponse =
-        (await response.json()) as Eip1967ProxyInfoResponse;
-      return proxyInfoResponse.proxyInfo;
-    } catch (error) {
-      console.warn("EIP-1967 proxy detection failed:", error);
-      return undefined;
+    const response = await fetch("/api/get_eip1967_proxy_info", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chainId, address }),
+    });
+    if (!response.ok) {
+      throw new Error(
+        (await response.json()).message ?? "EIP-1967 proxy detection failed."
+      );
     }
+
+    const proxyInfoResponse =
+      (await response.json()) as Eip1967ProxyInfoResponse;
+    return proxyInfoResponse.proxyInfo;
   }
 
   return (
@@ -775,7 +776,7 @@ export default function AnalyzeWizardButton({
               from sourcify
               {proxyInfo && (
                 <span className="block text-green-500 mt-2">
-                  EIP-1967 proxy detected. Fetching the sources of the active
+                  Upgradeable proxy detected. Fetching the sources of the active
                   implementation at {proxyInfo.implementationAddress}.
                 </span>
               )}
@@ -909,7 +910,7 @@ export default function AnalyzeWizardButton({
               contract to load storage layout.
               {proxyInfo && (
                 <span className="block text-green-500 mt-2">
-                  {address} is an EIP-1967 proxy: these contracts come from its
+                  {address} is an upgradeable proxy: these contracts come from its
                   active implementation at {proxyInfo.implementationAddress}.
                 </span>
               )}

--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -51,6 +51,10 @@ import type { SolcInput, SolcOutput } from "@openzeppelin/upgrades-core";
 import type { Dispatch, SetStateAction } from "react";
 import type { StorageLayout } from "@openzeppelin/upgrades-core";
 import type { ReactNode } from "react";
+import type {
+  Eip1967ProxyInfo,
+  Eip1967ProxyInfoResponse,
+} from "@/lib/eip1967";
 
 interface AnalyzeWizardButtonProps {
   setParentDialogOpen?: Dispatch<SetStateAction<boolean>>;
@@ -146,6 +150,12 @@ export default function AnalyzeWizardButton({
 
   // Address management with zod validation
   const [address, setAddress] = useState<string | undefined>(initialAddress);
+  const [sourceAddress, setSourceAddress] = useState<string | undefined>(
+    initialAddress
+  );
+  const [proxyInfo, setProxyInfo] = useState<Eip1967ProxyInfo | undefined>(
+    undefined
+  );
   const [addressError, setAddressError] = useState<string | undefined>(
     undefined
   );
@@ -205,6 +215,8 @@ export default function AnalyzeWizardButton({
     setChainsPopoverOpen(false);
     setChainName(undefined);
     setAddress(undefined);
+    setSourceAddress(undefined);
+    setProxyInfo(undefined);
     setCompilerBinary("");
     setSolcInput(undefined);
     setSolcOutput(undefined);
@@ -232,8 +244,18 @@ export default function AnalyzeWizardButton({
     setWizardStep(WizardStep.FETCHING);
 
     const chainId = chains.find((_chain) => _chain.name === chainName)?.chainId;
+    if (!chainId || !address) {
+      setWizardStep(WizardStep.SELECT_ADDRESS);
+      return;
+    }
+
+    const detectedProxyInfo = await fetchEip1967ProxyInfo(chainId, address);
+    const sourcifyAddress = detectedProxyInfo?.implementationAddress ?? address;
+    setProxyInfo(detectedProxyInfo);
+    setSourceAddress(sourcifyAddress);
+
     const response = await fetch(
-      `https://sourcify.dev/server/v2/contract/${chainId}/${address}?fields=stdJsonInput,compilation`,
+      `https://sourcify.dev/server/v2/contract/${chainId}/${sourcifyAddress}?fields=stdJsonInput,compilation`,
       {
         method: "GET",
       }
@@ -241,9 +263,12 @@ export default function AnalyzeWizardButton({
     if (!response.ok) {
       if (response.status === 404) {
         const data = await response.json();
+        const targetDescription = detectedProxyInfo
+          ? `Implementation ${sourcifyAddress} for proxy ${address}`
+          : `Contract at ${data.address}`;
         setFetchArtifactsError(
           <>
-            {`Contract at ${data.address} on chain id ${data.chainId} not verified on Sourcify. Please verify your contract using the `}
+            {`${targetDescription} on chain id ${data.chainId} not verified on Sourcify. Please verify your contract using the `}
             <a
               href="https://verify.sourcify.dev/"
               target="_blank"
@@ -504,6 +529,12 @@ export default function AnalyzeWizardButton({
   async function handleLoadStorageLayout() {
     setWizardStep(WizardStep.LOADING);
     if (!selectedContract || !solcInput || !solcOutput) return;
+    const displaySourceAddress =
+      sourceAddress &&
+      address &&
+      sourceAddress.toLowerCase() !== address.toLowerCase()
+        ? sourceAddress
+        : undefined;
 
     // Extract storage layout using backend
     let storageLayout: StorageLayout | undefined = undefined;
@@ -520,6 +551,7 @@ export default function AnalyzeWizardButton({
           contractName: selectedContract,
           chainId: chains.find((_chain) => _chain.name === chainName)?.chainId,
           address: address,
+          sourceAddress: sourceAddress,
         })
       );
       const _compressedBodyRequest = _brotli.compress(
@@ -557,7 +589,9 @@ export default function AnalyzeWizardButton({
             id: 0,
             storageLayout: storageLayout!,
             chainId: chains.find((_chain) => _chain.name === chainName)?.chainId,
-            address: address
+            address: address,
+            sourceAddress: displaySourceAddress,
+            proxyInfo: proxyInfo,
           },
           ...prevLayouts.slice(triggerVisualizerId + 1),
         ];
@@ -572,7 +606,9 @@ export default function AnalyzeWizardButton({
           id: 0,
           storageLayout: storageLayout!,
           chainId: chains.find((_chain) => _chain.name === chainName)?.chainId,
-          address: address
+          address: address,
+          sourceAddress: displaySourceAddress,
+          proxyInfo: proxyInfo,
         },
       ];
     });
@@ -582,6 +618,33 @@ export default function AnalyzeWizardButton({
     // Close parent dialog if exist
     if (setParentDialogOpen) {
       setParentDialogOpen(false);
+    }
+  }
+
+  async function fetchEip1967ProxyInfo(
+    chainId: number,
+    address: string
+  ): Promise<Eip1967ProxyInfo | undefined> {
+    try {
+      const response = await fetch("/api/get_eip1967_proxy_info", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chainId, address }),
+      });
+      if (!response.ok) {
+        console.warn(
+          "EIP-1967 proxy detection failed:",
+          (await response.json()).message
+        );
+        return undefined;
+      }
+
+      const proxyInfoResponse =
+        (await response.json()) as Eip1967ProxyInfoResponse;
+      return proxyInfoResponse.proxyInfo;
+    } catch (error) {
+      console.warn("EIP-1967 proxy detection failed:", error);
+      return undefined;
     }
   }
 
@@ -710,6 +773,12 @@ export default function AnalyzeWizardButton({
             >
               Please wait while your contract source files are being fetched
               from sourcify
+              {proxyInfo && (
+                <span className="block text-green-500 mt-2">
+                  EIP-1967 proxy detected. Fetching the sources of the active
+                  implementation at {proxyInfo.implementationAddress}.
+                </span>
+              )}
             </DialogDescription>
           </DialogHeader>
           <div className="flex items-center justify-center">
@@ -733,10 +802,10 @@ export default function AnalyzeWizardButton({
               {
                 //@ts-expect-error optimizer is not typed in SolcInput settings
                 solcInput?.settings?.optimizer?.enabled && (
-                  <p>
+                  <span className="block">
                     Compilation might take a while because the optimizer is
                     enabled.
-                  </p>
+                  </span>
                 )
               }
             </DialogDescription>
@@ -838,6 +907,12 @@ export default function AnalyzeWizardButton({
             >
               The contracts have been compiled successfully. Please select a
               contract to load storage layout.
+              {proxyInfo && (
+                <span className="block text-green-500 mt-2">
+                  {address} is an EIP-1967 proxy: these contracts come from its
+                  active implementation at {proxyInfo.implementationAddress}.
+                </span>
+              )}
             </DialogDescription>
           </DialogHeader>
           <div className="overflow-hidden">

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from "react";
+import { Fragment, useContext, useMemo, useState } from "react";
 import { Code2, Code, Share, X, Cross, TriangleAlert, Braces } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -42,9 +42,13 @@ import type {
   TypeItemMembers,
   StructMember,
 } from "@openzeppelin/upgrades-core";
+import type { Eip1967ProxyInfo } from "@/lib/eip1967";
 
 const SLOT_ZERO =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+const truncateAddress = (value: string) =>
+  `${value.slice(0, 10)}...${value.slice(-8)}`;
 
 // A type's `members` is either struct fields or enum value names (plain
 // strings) - only the former has its own slot/offset layout to unwrap.
@@ -263,6 +267,8 @@ export interface StorageVisualizerProps {
   storageLayout: StorageLayout;
   chainId: number | undefined;
   address: string | undefined;
+  sourceAddress?: string;
+  proxyInfo?: Eip1967ProxyInfo;
 }
 
 export default function StorageVisualizer({
@@ -271,6 +277,8 @@ export default function StorageVisualizer({
   storageLayout,
   chainId,
   address,
+  sourceAddress,
+  proxyInfo,
 }: StorageVisualizerProps) {
   // Global context
   const storageLayoutsContext = useContext(StorageLayoutsContext);
@@ -311,6 +319,8 @@ export default function StorageVisualizer({
               contractName,
               chainId,
               address,
+              sourceAddress,
+              proxyInfo,
               storageLayout,
               namespace:
                 activeTab === ROOT_LAYOUT_TAB ? undefined : activeTab,
@@ -396,6 +406,8 @@ export default function StorageVisualizer({
     return wrappers;
   }, [storageLayout]);
 
+  const sourcifyAddress = sourceAddress ?? address;
+
   return (
     <Card className="bg-black border-green-500 md:mb-4 overflow-hidden relative py-0 gap-0 h-full w-full transition-all duration-500 ease-in-out">
       {/* Upper Bar */}
@@ -404,10 +416,11 @@ export default function StorageVisualizer({
           <Code2 className="text-green-500 h-4 w-4" />
           <span className="text-green-500 text-sm font-bold">
             {chainId !== undefined && address !== undefined
-              ? `${contractName} (Addr: ${address.slice(
-                  0,
-                  10
-                )}...${address.slice(-8)} | Chain Id: ${chainId})`
+              ? `${contractName} (${
+                  proxyInfo
+                    ? `Proxy: ${truncateAddress(address)} | Impl: ${truncateAddress(proxyInfo.implementationAddress)}`
+                    : `Addr: ${truncateAddress(address)}`
+                } | Chain Id: ${chainId})`
               : contractName}
           </span>
         </div>
@@ -421,7 +434,7 @@ export default function StorageVisualizer({
                     size="icon"
                     onClick={() =>
                       window.open(
-                        `https://repo.sourcify.dev/${chainId.toString()}/${address}`,
+                        `https://repo.sourcify.dev/${chainId.toString()}/${sourcifyAddress}`,
                         "_blank"
                       )
                     }
@@ -431,7 +444,9 @@ export default function StorageVisualizer({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
-                  View code on Sourcify.eth
+                  {proxyInfo
+                    ? "View implementation code on Sourcify.eth"
+                    : "View code on Sourcify.eth"}
                 </TooltipContent>
               </Tooltip>
 
@@ -575,6 +590,30 @@ export default function StorageVisualizer({
         </div>
       </div>
 
+      {proxyInfo && (
+        <div className="border-b border-green-500/30 bg-green-900/10 px-4 py-2 text-[11px] text-green-500">
+          <span className="font-bold">EIP-1967 proxy detected.</span>{" "}
+          <span>Proxy storage: {truncateAddress(proxyInfo.proxyAddress)}</span>
+          <span className="mx-2">|</span>
+          <span>
+            Implementation layout:{" "}
+            {truncateAddress(proxyInfo.implementationAddress)}
+          </span>
+          {proxyInfo.beaconAddress && (
+            <>
+              <span className="mx-2">|</span>
+              <span>Beacon: {truncateAddress(proxyInfo.beaconAddress)}</span>
+            </>
+          )}
+          {proxyInfo.adminAddress && (
+            <>
+              <span className="mx-2">|</span>
+              <span>Admin: {truncateAddress(proxyInfo.adminAddress)}</span>
+            </>
+          )}
+        </div>
+      )}
+
       {/* Tabs*/}
       <Tabs value={activeTab} onValueChange={setSelectedTab} className="w-full">
         <div
@@ -589,7 +628,7 @@ export default function StorageVisualizer({
         >
           <TabsList className="bg-transparent h-9 flex items-center whitespace-nowrap">
             {storageLayouts.map((layout) => (
-              <>
+              <Fragment key={layout.name}>
                 <TabsTrigger
                   value={layout.name}
                   className="text-green-500 data-[state=active]:bg-green-900/30 data-[state=active]:text-green-500 data-[state=active]:shadow-none rounded-none border-r"
@@ -597,24 +636,31 @@ export default function StorageVisualizer({
                   {layout.name}
                 </TabsTrigger>
                 <div className="w-px h-6 bg-green-500 mx-2 self-center" />
-              </>
+              </Fragment>
             ))}
           </TabsList>
         </div>
 
         {/*Content */}
         {storageLayouts.map((layout, index) => (
-          <TabsContent value={layout.name} className="mt-0">
+          <TabsContent key={layout.name} value={layout.name} className="mt-0">
             {layout.baseSlot !== undefined && (
               <div className="px-4 pb-2 text-green-500 text-[8px] md:text-[11px]">
                 base slot: {layout.baseSlot}
               </div>
             )}
             {layout.slots.length === 0 && (
-              <div className="flex items-center justify-center gap-2 px-4 pb-2 my-5 text-green-500">
-                <TriangleAlert className="h-4 w-4" />
-                <span className="text-center">
-                  {layout.name} has no storage items defined.
+              <div className="flex flex-col items-center gap-1 px-4 pb-2 my-5 text-green-500">
+                <div className="flex items-center justify-center gap-2">
+                  <TriangleAlert className="h-4 w-4" />
+                  <span className="text-center">
+                    {layout.name} has no storage items defined.
+                  </span>
+                </div>
+                <span className="text-center text-green-500/60 text-xs">
+                  The contract may only use constants/immutables, or keep its
+                  state in unstructured storage (manually computed slots),
+                  which the compiler's storage layout cannot describe.
                 </span>
               </div>
             )}

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -42,6 +42,7 @@ import type {
   TypeItemMembers,
   StructMember,
 } from "@openzeppelin/upgrades-core";
+import { proxyKindLabel } from "@/lib/eip1967";
 import type { Eip1967ProxyInfo } from "@/lib/eip1967";
 
 const SLOT_ZERO =
@@ -592,7 +593,9 @@ export default function StorageVisualizer({
 
       {proxyInfo && (
         <div className="border-b border-green-500/30 bg-green-900/10 px-4 py-2 text-[11px] text-green-500">
-          <span className="font-bold">EIP-1967 proxy detected.</span>{" "}
+          <span className="font-bold">
+            {proxyKindLabel(proxyInfo.kind)} detected.
+          </span>{" "}
           <span>Proxy storage: {truncateAddress(proxyInfo.proxyAddress)}</span>
           <span className="mx-2">|</span>
           <span>

--- a/src/lib/eip1967.ts
+++ b/src/lib/eip1967.ts
@@ -1,5 +1,7 @@
 export interface Eip1967ProxyInfo {
-  kind: "eip1967" | "beacon";
+  // "legacy" = implementation found via the pre-EIP-1967 ZeppelinOS slot
+  // (keccak256("org.zeppelinos.proxy.implementation")), e.g. USDC.
+  kind: "eip1967" | "beacon" | "legacy";
   proxyAddress: string;
   implementationAddress: string;
   adminAddress?: string;
@@ -10,4 +12,15 @@ export interface Eip1967ProxyInfoResponse {
   isProxy: boolean;
   proxyInfo?: Eip1967ProxyInfo;
   message?: string;
+}
+
+export function proxyKindLabel(kind: Eip1967ProxyInfo["kind"]): string {
+  switch (kind) {
+    case "beacon":
+      return "EIP-1967 beacon proxy";
+    case "legacy":
+      return "Legacy upgradeable proxy (pre-EIP-1967 slots)";
+    default:
+      return "EIP-1967 proxy";
+  }
 }

--- a/src/lib/eip1967.ts
+++ b/src/lib/eip1967.ts
@@ -1,0 +1,13 @@
+export interface Eip1967ProxyInfo {
+  kind: "eip1967" | "beacon";
+  proxyAddress: string;
+  implementationAddress: string;
+  adminAddress?: string;
+  beaconAddress?: string;
+}
+
+export interface Eip1967ProxyInfoResponse {
+  isProxy: boolean;
+  proxyInfo?: Eip1967ProxyInfo;
+  message?: string;
+}

--- a/src/lib/storage-layout-export.ts
+++ b/src/lib/storage-layout-export.ts
@@ -1,6 +1,7 @@
 import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
 import { deriveNamespaceBaseSlot } from "@/lib/erc7201";
 import { normalizeUint256Literal } from "@/lib/integer-literals";
+import type { Eip1967ProxyInfo } from "@/lib/eip1967";
 
 const EXPORT_SCHEMA_VERSION = "evm-storage.codes/storage-layout-export@1";
 const JSON_INDENT_SPACES = 2;
@@ -14,6 +15,8 @@ export type LayoutEntry = {
   contractName: string;
   chainId: number | undefined;
   address: string | undefined;
+  sourceAddress?: string;
+  proxyInfo?: Eip1967ProxyInfo;
   storageLayout: StorageLayout;
 };
 
@@ -117,7 +120,14 @@ function buildWrapper(
   mode: "full" | "tab",
   namespace?: string,
 ): Record<string, unknown> {
-  const { contractName, chainId, address, storageLayout } = entry;
+  const {
+    contractName,
+    chainId,
+    address,
+    sourceAddress,
+    proxyInfo,
+    storageLayout,
+  } = entry;
   const allTypes = (storageLayout.types ?? {}) as RawTypes;
 
   if (mode === "full") {
@@ -150,6 +160,8 @@ function buildWrapper(
       contractName,
       chainId,
       address,
+      sourceAddress,
+      proxyInfo,
       solcVersion: storageLayout.solcVersion,
       layoutVersion: storageLayout.layoutVersion,
       baseSlot: normalizedRootBaseSlot(storageLayout),
@@ -182,6 +194,8 @@ function buildWrapper(
     contractName,
     chainId,
     address,
+    sourceAddress,
+    proxyInfo,
     solcVersion: storageLayout.solcVersion,
     layoutVersion: storageLayout.layoutVersion,
     namespace,


### PR DESCRIPTION
Closes #34

## What

When an analyzed address is a proxy, the app now detects it and displays the storage layout of its **active implementation** instead of the proxy's own layout (which is normally empty, since proxies typically keep zero declared storage variables outside their EIP-1967 slots).

This also fixes a related, previously-silent gap: even non-upgradeable contracts that only declare constants/immutables, or that manage state via manually-computed ("unstructured") storage slots, would render a bare "no storage items defined" warning with no explanation. That message now includes a short hint about why the layout can legitimately be empty.

## Detection: EIP-1967 vs. legacy vs. beacon

Proxy detection reuses `@openzeppelin/upgrades-core`'s own `getImplementationAddress` / `getBeaconAddress` / `getAdminAddress`, run server-side (`api/get_eip1967_proxy_info.js`, `api/_lib/eip1967.js`) against public RPC endpoints (Sourcify's chain list plus a small hardcoded fallback for major chains, since not every chain in Sourcify's list ships a usable public RPC).

One nuance surfaced during review: `getImplementationAddress` deliberately also resolves the **pre-EIP-1967 ZeppelinOS** implementation slot (`keccak256("org.zeppelinos.proxy.implementation")`) as a fallback — this is a real, still-in-use pattern (e.g. **USDC**, `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`, whose EIP-1967 slot is empty and whose implementation lives only in that legacy slot). Treating every detection hit as "EIP-1967" would mislabel these. The backend now reads the EIP-1967 slot directly to tell the two apart, so `proxyInfo.kind` is one of:
- `"eip1967"` — implementation resolved via the EIP-1967 slot directly.
- `"legacy"` — implementation only resolved via the pre-EIP-1967 ZeppelinOS slot (USDC).
- `"beacon"` — implementation resolved via an EIP-1967 beacon.

The visualizer banner shows the specific kind (e.g. "Legacy upgradeable proxy (pre-EIP-1967 slots) detected."); wizard-step copy uses kind-neutral "upgradeable proxy" wording since the distinction isn't decision-relevant to the user at that point.

Design choice: proxy detection is treated as best-effort, not a hard requirement. If it fails (chain with no usable public RPC, RPCs down, timeout) the wizard logs a warning and falls back to analyzing the address as-is, rather than blocking analysis of contracts that aren't proxies at all — an earlier version of this made detection failures fatal, which would have broken the tool for any chain without solid public RPC coverage.

## Fetch/compile pipeline

`AnalyzeWizardButton` resolves the proxy (if any) *before* contacting Sourcify, then fetches and compiles the **implementation's** sources, not the proxy's. The detection is surfaced explicitly in the "Fetching sources" and "Select a Contract" steps (e.g. "Upgradeable proxy detected. Fetching the sources of the active implementation at 0x…") so the address substitution is never silent — the user always knows which contract's code they're actually looking at.

## Caching and share links

Storage layouts are cached in Redis keyed by the **proxy's** `chainId:address` (so share links to the proxy address keep working), but the cached entry stores the resolved `sourceAddress`/`proxyInfo` alongside the implementation's layout. Before writing to cache, `extract_storage_layout.js` re-resolves the proxy server-side and requires the claimed implementation to match — mirroring the existing Sourcify-sources integrity check already in place for non-proxy contracts — so a malicious frontend can't poison the cache with a fabricated proxy/implementation pairing.

The trickier case is **cache staleness after an upgrade**: a proxy's implementation can change after its layout was cached, which would otherwise serve the pre-upgrade layout indefinitely on every future share-link visit. `get_cached_storage_layout.js` now re-resolves the proxy on every read of a cached proxy entry and treats a changed implementation as a cache miss, so the wizard regenerates (and re-caches) the current one. Cached proxy entries are served with `Cache-Control: no-store` (instead of the `s-maxage=86400` used for non-proxy entries) so the CDN can't paper over that check with a stale edge cache. If the staleness check itself fails (RPCs down), it fails open and serves the possibly-stale entry rather than breaking the share link outright — a share link that occasionally shows a stale-but-plausible layout is a better failure mode than one that 500s whenever public RPCs hiccup.

## UI

- `StorageVisualizer`: a proxy banner (proxy / implementation / admin / beacon addresses) and a `Proxy: … | Impl: …` header replace the old bare address header; the "view code on Sourcify" link points at the implementation, not the proxy.
- Empty-layout message now explains itself instead of just warning.
- Drive-by fixes to console errors surfaced while manually testing this flow with Playwright: invalid `<p>`-in-`<p>` nesting inside `DialogDescription`, and missing React keys in the visualizer's tab-list rendering.

## Examples

| Address | Chain | Result |
|---|---|---|
| `0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2` (Aave V3 Pool) | mainnet | `kind: "eip1967"`, implementation `PoolInstance` compiled, 61 slots rendered |
| `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` (USDC) | mainnet | `kind: "legacy"`, implementation `FiatTokenV2_2` compiled, 19 slots rendered, banner reads "Legacy upgradeable proxy (pre-EIP-1967 slots) detected." |
| `0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1` (Lido WithdrawalQueue) | mainnet | `kind: "eip1967"`, implementation compiled, but the layout is genuinely empty — Lido's contracts keep all state in manually-computed unstructured storage slots, not declared Solidity variables. This was the address that originally prompted this feature (it rendered "Root layout has no storage items defined." with no context); it's now labeled as a proxy with an explanation of why the layout is empty rather than looking broken. |

## Verification

`yarn lint` and `yarn build` pass. End-to-end verification via Playwright against a local `yarn vercel dev`, using a small local shim implementing the Upstash REST API (`GET`/`SET`/pipeline) since this project has no local Redis credentials — this only stood in for the cache backend; all proxy detection and compilation hit real public RPCs/Sourcify:

- Aave, USDC, Lido (proxies): wizard flow → correct `kind`, correct implementation compiled, banner/header rendered, non-empty (Aave/USDC) or empty-with-hint (Lido) layout as expected.
- UNI token (non-proxy regression): unchanged behavior, no proxy UI, no console errors.
- Share-link roundtrip: a wizard-driven load caches the proxy layout (exercising the server-side re-verification), then `/?chainId=1&address=<proxy>` renders the cached implementation layout + banner without recompiling.
- Cache staleness: manually tampering the cached `proxyInfo.implementationAddress` via the shim causes the next share-link load to 404 as "outdated" rather than serving the stale layout; restoring the original value serves it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)