### PR TITLE
fix: initialize address input as controlled from the start

### DIFF
--- a/api/_lib/eip1967.js
+++ b/api/_lib/eip1967.js
@@ -8,6 +8,13 @@ import {
 } from "@openzeppelin/upgrades-core";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+// keccak256("eip1967.proxy.implementation") - 1. upgrades-core's
+// getImplementationAddress also falls back to the pre-EIP-1967 ZeppelinOS
+// slot (keccak256("org.zeppelinos.proxy.implementation")), so when it
+// resolves an implementation we read this slot directly to tell the two
+// kinds apart (e.g. USDC is a legacy zos proxy, not EIP-1967).
+const EIP1967_IMPLEMENTATION_SLOT =
+  "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
 const RPC_TIMEOUT_MS = 4_000;
 // Detection makes up to three RPC calls (implementation, beacon, admin) and
 // each call retries every candidate URL, so keep the list short enough that a
@@ -53,17 +60,39 @@ export async function getEip1967ProxyInfo(chainId, address) {
     return { isProxy: false };
   }
 
+  let kind = beaconAddress ? "beacon" : "eip1967";
+  if (
+    directImplementationAddress &&
+    !(await isEip1967ImplementationSlotSet(provider, address))
+  ) {
+    kind = "legacy";
+  }
+
   const adminAddress = await getOptionalAdminAddress(provider, address);
   return {
     isProxy: true,
     proxyInfo: {
-      kind: beaconAddress ? "beacon" : "eip1967",
+      kind,
       proxyAddress: address,
       implementationAddress,
       ...(adminAddress ? { adminAddress } : {}),
       ...(beaconAddress ? { beaconAddress } : {}),
     },
   };
+}
+
+async function isEip1967ImplementationSlotSet(provider, address) {
+  try {
+    const rawSlot = await provider.send("eth_getStorageAt", [
+      address,
+      EIP1967_IMPLEMENTATION_SLOT,
+      "latest",
+    ]);
+    return Boolean(rawSlot) && BigInt(rawSlot) !== 0n;
+  } catch {
+    // Can't tell the kinds apart - keep the default EIP-1967 label.
+    return true;
+  }
 }
 
 export function isAddress(value) {

--- a/api/_lib/eip1967.js
+++ b/api/_lib/eip1967.js
@@ -1,0 +1,203 @@
+import {
+  EIP1967BeaconNotFound,
+  EIP1967ImplementationNotFound,
+  getAdminAddress,
+  getBeaconAddress,
+  getImplementationAddress,
+  getImplementationAddressFromBeacon,
+} from "@openzeppelin/upgrades-core";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const RPC_TIMEOUT_MS = 4_000;
+// Detection makes up to three RPC calls (implementation, beacon, admin) and
+// each call retries every candidate URL, so keep the list short enough that a
+// chain full of dead RPCs can't run past the serverless function timeout.
+const MAX_RPC_URLS = 5;
+const FALLBACK_RPC_URLS = {
+  1: [
+    "https://ethereum-rpc.publicnode.com",
+    "https://rpc.flashbots.net",
+    "https://eth.merkle.io",
+  ],
+  10: ["https://mainnet.optimism.io"],
+  56: ["https://bsc-dataseed.binance.org"],
+  137: ["https://polygon-rpc.com"],
+  8453: ["https://mainnet.base.org"],
+  42161: ["https://arb1.arbitrum.io/rpc"],
+  43114: ["https://api.avax.network/ext/bc/C/rpc"],
+  11155111: ["https://ethereum-sepolia-rpc.publicnode.com"],
+};
+
+export async function getEip1967ProxyInfo(chainId, address) {
+  const rpcUrls = await getRpcUrls(chainId);
+  if (rpcUrls.length === 0) {
+    throw new Error(`No public HTTPS RPC URL found for chain ID ${chainId}.`);
+  }
+
+  const provider = createFallbackProvider(rpcUrls);
+  const directImplementationAddress = await getOptionalImplementationAddress(
+    provider,
+    address
+  );
+  const beaconAddress = directImplementationAddress
+    ? undefined
+    : await getOptionalBeaconAddress(provider, address);
+  const beaconImplementationAddress = beaconAddress
+    ? await getImplementationAddressFromBeacon(provider, beaconAddress)
+    : undefined;
+
+  const implementationAddress =
+    directImplementationAddress ?? beaconImplementationAddress;
+
+  if (!implementationAddress) {
+    return { isProxy: false };
+  }
+
+  const adminAddress = await getOptionalAdminAddress(provider, address);
+  return {
+    isProxy: true,
+    proxyInfo: {
+      kind: beaconAddress ? "beacon" : "eip1967",
+      proxyAddress: address,
+      implementationAddress,
+      ...(adminAddress ? { adminAddress } : {}),
+      ...(beaconAddress ? { beaconAddress } : {}),
+    },
+  };
+}
+
+export function isAddress(value) {
+  return /^0x[0-9a-fA-F]{40}$/.test(value);
+}
+
+export function sameAddress(left, right) {
+  return left?.toLowerCase() === right?.toLowerCase();
+}
+
+async function getRpcUrls(chainId) {
+  const fallbackUrls = FALLBACK_RPC_URLS[chainId] ?? [];
+  try {
+    const response = await fetch("https://sourcify.dev/server/chains", {
+      signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error("Failed to fetch Sourcify chain metadata.");
+    }
+
+    const chains = await response.json();
+    const chain = chains.find((candidate) => candidate.chainId === chainId);
+    if (!chain && fallbackUrls.length === 0) {
+      throw new Error(`Chain ID ${chainId} is not listed by Sourcify.`);
+    }
+
+    return [
+      ...fallbackUrls,
+      ...(chain?.rpc ?? []),
+      ...(chain?.traceSupportedRPCs ?? []),
+    ]
+      .filter(isUsableRpcUrl)
+      .filter((url, index, urls) => urls.indexOf(url) === index)
+      .slice(0, MAX_RPC_URLS);
+  } catch (error) {
+    if (fallbackUrls.length > 0) {
+      return fallbackUrls;
+    }
+    throw error;
+  }
+}
+
+function isUsableRpcUrl(url) {
+  return (
+    typeof url === "string" &&
+    url.startsWith("https://") &&
+    !url.includes("${") &&
+    !url.includes("{") &&
+    !url.includes("}") &&
+    !url.includes("localhost") &&
+    !url.includes("127.0.0.1")
+  );
+}
+
+function createFallbackProvider(rpcUrls) {
+  let preferredRpcUrl;
+  return {
+    async send(method, params) {
+      const errors = [];
+      const orderedRpcUrls = preferredRpcUrl
+        ? [preferredRpcUrl, ...rpcUrls.filter((url) => url !== preferredRpcUrl)]
+        : rpcUrls;
+      for (const rpcUrl of orderedRpcUrls) {
+        try {
+          const result = await sendRpc(rpcUrl, method, params);
+          preferredRpcUrl = rpcUrl;
+          return result;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : error;
+          errors.push(`${rpcUrl}: ${message}`);
+        }
+      }
+      throw new Error(
+        `All RPC URLs failed for ${method}: ${errors.join(" | ")}`
+      );
+    },
+  };
+}
+
+async function sendRpc(rpcUrl, method, params) {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      params,
+    }),
+    signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.message ?? "RPC error");
+  }
+  return payload.result;
+}
+
+async function getOptionalImplementationAddress(provider, address) {
+  try {
+    return await getImplementationAddress(provider, address);
+  } catch (error) {
+    if (error instanceof EIP1967ImplementationNotFound) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function getOptionalBeaconAddress(provider, address) {
+  try {
+    return await getBeaconAddress(provider, address);
+  } catch (error) {
+    if (error instanceof EIP1967BeaconNotFound) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function getOptionalAdminAddress(provider, address) {
+  // The admin address is informational only - a failure reading it must not
+  // discard an already-successful implementation detection.
+  try {
+    const adminAddress = await getAdminAddress(provider, address);
+    return adminAddress.toLowerCase() === ZERO_ADDRESS
+      ? undefined
+      : adminAddress;
+  } catch {
+    return undefined;
+  }
+}

--- a/api/_lib/eip1967.js
+++ b/api/_lib/eip1967.js
@@ -6,6 +6,7 @@ import {
   getImplementationAddress,
   getImplementationAddressFromBeacon,
 } from "@openzeppelin/upgrades-core";
+import { getRpcUrls, createFallbackProvider } from "./rpc.js";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 // keccak256("eip1967.proxy.implementation") - 1. upgrades-core's
@@ -15,25 +16,6 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 // kinds apart (e.g. USDC is a legacy zos proxy, not EIP-1967).
 const EIP1967_IMPLEMENTATION_SLOT =
   "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
-const RPC_TIMEOUT_MS = 4_000;
-// Detection makes up to three RPC calls (implementation, beacon, admin) and
-// each call retries every candidate URL, so keep the list short enough that a
-// chain full of dead RPCs can't run past the serverless function timeout.
-const MAX_RPC_URLS = 5;
-const FALLBACK_RPC_URLS = {
-  1: [
-    "https://ethereum-rpc.publicnode.com",
-    "https://rpc.flashbots.net",
-    "https://eth.merkle.io",
-  ],
-  10: ["https://mainnet.optimism.io"],
-  56: ["https://bsc-dataseed.binance.org"],
-  137: ["https://polygon-rpc.com"],
-  8453: ["https://mainnet.base.org"],
-  42161: ["https://arb1.arbitrum.io/rpc"],
-  43114: ["https://api.avax.network/ext/bc/C/rpc"],
-  11155111: ["https://ethereum-sepolia-rpc.publicnode.com"],
-};
 
 export async function getEip1967ProxyInfo(chainId, address) {
   const rpcUrls = await getRpcUrls(chainId);
@@ -101,99 +83,6 @@ export function isAddress(value) {
 
 export function sameAddress(left, right) {
   return left?.toLowerCase() === right?.toLowerCase();
-}
-
-async function getRpcUrls(chainId) {
-  const fallbackUrls = FALLBACK_RPC_URLS[chainId] ?? [];
-  try {
-    const response = await fetch("https://sourcify.dev/server/chains", {
-      signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
-    });
-    if (!response.ok) {
-      throw new Error("Failed to fetch Sourcify chain metadata.");
-    }
-
-    const chains = await response.json();
-    const chain = chains.find((candidate) => candidate.chainId === chainId);
-    if (!chain && fallbackUrls.length === 0) {
-      throw new Error(`Chain ID ${chainId} is not listed by Sourcify.`);
-    }
-
-    return [
-      ...fallbackUrls,
-      ...(chain?.rpc ?? []),
-      ...(chain?.traceSupportedRPCs ?? []),
-    ]
-      .filter(isUsableRpcUrl)
-      .filter((url, index, urls) => urls.indexOf(url) === index)
-      .slice(0, MAX_RPC_URLS);
-  } catch (error) {
-    if (fallbackUrls.length > 0) {
-      return fallbackUrls;
-    }
-    throw error;
-  }
-}
-
-function isUsableRpcUrl(url) {
-  return (
-    typeof url === "string" &&
-    url.startsWith("https://") &&
-    !url.includes("${") &&
-    !url.includes("{") &&
-    !url.includes("}") &&
-    !url.includes("localhost") &&
-    !url.includes("127.0.0.1")
-  );
-}
-
-function createFallbackProvider(rpcUrls) {
-  let preferredRpcUrl;
-  return {
-    async send(method, params) {
-      const errors = [];
-      const orderedRpcUrls = preferredRpcUrl
-        ? [preferredRpcUrl, ...rpcUrls.filter((url) => url !== preferredRpcUrl)]
-        : rpcUrls;
-      for (const rpcUrl of orderedRpcUrls) {
-        try {
-          const result = await sendRpc(rpcUrl, method, params);
-          preferredRpcUrl = rpcUrl;
-          return result;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : error;
-          errors.push(`${rpcUrl}: ${message}`);
-        }
-      }
-      throw new Error(
-        `All RPC URLs failed for ${method}: ${errors.join(" | ")}`
-      );
-    },
-  };
-}
-
-async function sendRpc(rpcUrl, method, params) {
-  const response = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method,
-      params,
-    }),
-    signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
-  });
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
-  }
-
-  const payload = await response.json();
-  if (payload.error) {
-    throw new Error(payload.error.message ?? "RPC error");
-  }
-  return payload.result;
 }
 
 async function getOptionalImplementationAddress(provider, address) {

--- a/api/_lib/rpc.js
+++ b/api/_lib/rpc.js
@@ -1,0 +1,112 @@
+const RPC_TIMEOUT_MS = 4_000;
+// Detection/read calls retry every candidate URL on failure, so keep the
+// list short enough that a chain full of dead RPCs can't run past the
+// serverless function timeout.
+const MAX_RPC_URLS = 5;
+const FALLBACK_RPC_URLS = {
+  1: [
+    "https://ethereum-rpc.publicnode.com",
+    "https://rpc.flashbots.net",
+    "https://eth.merkle.io",
+  ],
+  10: ["https://mainnet.optimism.io"],
+  56: ["https://bsc-dataseed.binance.org"],
+  137: ["https://polygon-rpc.com"],
+  8453: ["https://mainnet.base.org"],
+  42161: ["https://arb1.arbitrum.io/rpc"],
+  43114: ["https://api.avax.network/ext/bc/C/rpc"],
+  11155111: ["https://ethereum-sepolia-rpc.publicnode.com"],
+};
+
+export async function getRpcUrls(chainId) {
+  const fallbackUrls = FALLBACK_RPC_URLS[chainId] ?? [];
+  try {
+    const response = await fetch("https://sourcify.dev/server/chains", {
+      signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error("Failed to fetch Sourcify chain metadata.");
+    }
+
+    const chains = await response.json();
+    const chain = chains.find((candidate) => candidate.chainId === chainId);
+    if (!chain && fallbackUrls.length === 0) {
+      throw new Error(`Chain ID ${chainId} is not listed by Sourcify.`);
+    }
+
+    return [
+      ...fallbackUrls,
+      ...(chain?.rpc ?? []),
+      ...(chain?.traceSupportedRPCs ?? []),
+    ]
+      .filter(isUsableRpcUrl)
+      .filter((url, index, urls) => urls.indexOf(url) === index)
+      .slice(0, MAX_RPC_URLS);
+  } catch (error) {
+    if (fallbackUrls.length > 0) {
+      return fallbackUrls;
+    }
+    throw error;
+  }
+}
+
+function isUsableRpcUrl(url) {
+  return (
+    typeof url === "string" &&
+    url.startsWith("https://") &&
+    !url.includes("${") &&
+    !url.includes("{") &&
+    !url.includes("}") &&
+    !url.includes("localhost") &&
+    !url.includes("127.0.0.1")
+  );
+}
+
+export function createFallbackProvider(rpcUrls) {
+  let preferredRpcUrl;
+  return {
+    async send(method, params) {
+      const errors = [];
+      const orderedRpcUrls = preferredRpcUrl
+        ? [preferredRpcUrl, ...rpcUrls.filter((url) => url !== preferredRpcUrl)]
+        : rpcUrls;
+      for (const rpcUrl of orderedRpcUrls) {
+        try {
+          const result = await sendRpc(rpcUrl, method, params);
+          preferredRpcUrl = rpcUrl;
+          return result;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : error;
+          errors.push(`${rpcUrl}: ${message}`);
+        }
+      }
+      throw new Error(
+        `All RPC URLs failed for ${method}: ${errors.join(" | ")}`
+      );
+    },
+  };
+}
+
+async function sendRpc(rpcUrl, method, params) {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      params,
+    }),
+    signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.message ?? "RPC error");
+  }
+  return payload.result;
+}

--- a/api/_lib/value-metadata-version.js
+++ b/api/_lib/value-metadata-version.js
@@ -1,0 +1,9 @@
+// Bump when the shape of data on-chain value-decoding relies on (currently:
+// types[].encoding/base/key/value, merged onto the layout by
+// extract_storage_layout.js) changes in a way that makes older cached
+// entries unusable for that purpose. get_cached_storage_layout.js compares
+// a cached entry's stamped version against this and treats a mismatch (or
+// its absence, for entries cached before this existed) as a cache miss, so
+// the layout regenerates and re-caches in the current shape instead of
+// silently degrading.
+export const VALUE_METADATA_VERSION = 1;

--- a/api/extract_storage_layout.js
+++ b/api/extract_storage_layout.js
@@ -6,6 +6,7 @@ import { brotliDecompressSync } from "zlib";
 import { findAll, astDereferencer, isNodeType } from "solidity-ast/utils.js";
 import { Redis } from "@upstash/redis";
 import { getEip1967ProxyInfo, sameAddress } from "./_lib/eip1967.js";
+import { VALUE_METADATA_VERSION } from "./_lib/value-metadata-version.js";
 
 export async function POST(request) {
   try {
@@ -142,6 +143,11 @@ export async function POST(request) {
               ? sourceAddress
               : undefined,
           proxyInfo: cacheProxyInfo,
+          // Bump this if the shape of data value-decoding relies on
+          // (currently: types[].encoding/base/key/value) changes again -
+          // get_cached_storage_layout.js treats a mismatch as a cache miss
+          // so old entries get regenerated instead of silently degrading.
+          valueMetadataVersion: VALUE_METADATA_VERSION,
         });
         //await redis.set(cacheKey, storageLayout, {
         //  nx: true, // only store if not already exists

--- a/api/extract_storage_layout.js
+++ b/api/extract_storage_layout.js
@@ -5,6 +5,7 @@ import {
 import { brotliDecompressSync } from "zlib";
 import { findAll, astDereferencer, isNodeType } from "solidity-ast/utils.js";
 import { Redis } from "@upstash/redis";
+import { getEip1967ProxyInfo, sameAddress } from "./_lib/eip1967.js";
 
 export async function POST(request) {
   try {
@@ -23,6 +24,7 @@ export async function POST(request) {
     const contractName = decompressedDataJson.contractName;
     const chainId = decompressedDataJson.chainId;
     const address = decompressedDataJson.address;
+    const sourceAddress = decompressedDataJson.sourceAddress;
 
     // Build decodeSrc function
     const decodeSrc = solcInputOutputDecoder(solcInput, solcOutput);
@@ -53,12 +55,35 @@ export async function POST(request) {
       getNamespacedCompilationContext(sourceName, contractDef, namespacedOutput)
     );
 
-    // Cache the storage layout in the database if it is not already cached
+    // Cache the storage layout in the database if it is not already cached.
     if (chainId && address) {
       try {
+        let integrityAddress = address;
+        let cacheProxyInfo = undefined;
+        if (sourceAddress && !sameAddress(sourceAddress, address)) {
+          const proxyResolution = await getEip1967ProxyInfo(
+            Number(chainId),
+            address
+          );
+          if (
+            !proxyResolution.proxyInfo ||
+            !sameAddress(
+              proxyResolution.proxyInfo.implementationAddress,
+              sourceAddress
+            )
+          ) {
+            console.warn(
+              "Proxy implementation does not match provided sourceAddress; storage layout wont be cached"
+            );
+            throw new Error("");
+          }
+          integrityAddress = sourceAddress;
+          cacheProxyInfo = proxyResolution.proxyInfo;
+        }
+
         // Minimal integrity test
         const response = await fetch(
-          `https://sourcify.dev/server/v2/contract/${chainId}/${address}?fields=stdJsonInput,compilation`,
+          `https://sourcify.dev/server/v2/contract/${chainId}/${integrityAddress}?fields=stdJsonInput,compilation`,
           {
             method: "GET",
           }
@@ -92,6 +117,11 @@ export async function POST(request) {
         await redis.set(cacheKey, {
           storageLayout: storageLayout,
           contractName: contractName,
+          sourceAddress:
+            sourceAddress && !sameAddress(sourceAddress, address)
+              ? sourceAddress
+              : undefined,
+          proxyInfo: cacheProxyInfo,
         });
         //await redis.set(cacheKey, storageLayout, {
         //  nx: true, // only store if not already exists

--- a/api/extract_storage_layout.js
+++ b/api/extract_storage_layout.js
@@ -47,12 +47,32 @@ export async function POST(request) {
     const deref = astDereferencer(solcOutput);
 
     // Extract the storage layout
+    const rawStorageLayout =
+      solcOutput.contracts[sourceName][contractDef.name].storageLayout;
+    const namespacedContext = getNamespacedCompilationContext(
+      sourceName,
+      contractDef,
+      namespacedOutput
+    );
     const storageLayout = extractStorageLayout(
       contractDef,
       decodeSrc,
       deref,
-      solcOutput.contracts[sourceName][contractDef.name].storageLayout,
-      getNamespacedCompilationContext(sourceName, contractDef, namespacedOutput)
+      rawStorageLayout,
+      namespacedContext
+    );
+
+    // upgrades-core's extractStorageLayout only keeps label/members/
+    // numberOfBytes on each type entry - it deliberately drops solc's
+    // `encoding`/`base`/`key`/`value` fields, which it doesn't need for its
+    // own purposes but which the frontend needs to decode on-chain values
+    // (encoding distinguishes a plain scalar from a mapping/array/dynamic
+    // bytes, and base/key/value point at the relevant sub-type). Merge them
+    // back in from the raw solc output(s) we already have on hand.
+    enrichTypesWithSolcFields(
+      storageLayout,
+      rawStorageLayout,
+      namespacedContext?.storageLayout
     );
 
     // Cache the storage layout in the database if it is not already cached.
@@ -143,6 +163,21 @@ export async function POST(request) {
       status: 500,
       headers: { "Content-Type": "application/json" },
     });
+  }
+}
+
+function enrichTypesWithSolcFields(layout, ...rawLayouts) {
+  const rawTypes = Object.assign(
+    {},
+    ...rawLayouts.filter(Boolean).map((rawLayout) => rawLayout.types ?? {})
+  );
+  for (const [id, type] of Object.entries(layout.types)) {
+    const raw = rawTypes[id];
+    if (!raw) continue;
+    if (raw.encoding !== undefined) type.encoding = raw.encoding;
+    if (raw.base !== undefined) type.base = raw.base;
+    if (raw.key !== undefined) type.key = raw.key;
+    if (raw.value !== undefined) type.value = raw.value;
   }
 }
 

--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -35,6 +35,8 @@ export async function POST(request) {
       JSON.stringify({
         storageLayout: entry.storageLayout,
         contractName: entry.contractName,
+        sourceAddress: entry.sourceAddress,
+        proxyInfo: entry.proxyInfo,
       }),
       {
         status: 200,

--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -1,17 +1,19 @@
 import { Redis } from "@upstash/redis";
+import {
+  getEip1967ProxyInfo,
+  isAddress,
+  sameAddress,
+} from "./_lib/eip1967.js";
 
 export async function POST(request) {
   try {
     const { chainId, address } = await request.json();
 
     if (!chainId || !address) {
-      return new Response(
-        JSON.stringify({ message: "Chain ID and address are required." }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        }
-      );
+      return jsonResponse({ message: "Chain ID and address are required." }, 400);
+    }
+    if (!/^\d+$/.test(String(chainId)) || !isAddress(address)) {
+      return jsonResponse({ message: "Invalid chain ID or address." }, 400);
     }
 
     // Cache the storage layout in Redis
@@ -20,39 +22,66 @@ export async function POST(request) {
     const entry = await redis.get(cacheKey);
 
     if (!entry?.storageLayout) {
-      return new Response(
-        JSON.stringify({ message: "Storage layout not cached." }),
-        {
-          status: 404,
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
-      );
+      return cacheMissResponse();
     }
 
-    return new Response(
-      JSON.stringify({
+    // Proxies can be upgraded after their layout was cached, which would
+    // leave us serving the old implementation's layout forever. Re-resolve
+    // the proxy and treat a changed implementation as a cache miss so the
+    // wizard regenerates (and re-caches) the current one. If the check
+    // itself fails (RPCs down), serve the possibly-stale entry rather than
+    // breaking the share link.
+    if (entry.proxyInfo?.implementationAddress) {
+      try {
+        const proxyResolution = await getEip1967ProxyInfo(
+          Number(chainId),
+          address
+        );
+        if (
+          !proxyResolution.proxyInfo ||
+          !sameAddress(
+            proxyResolution.proxyInfo.implementationAddress,
+            entry.proxyInfo.implementationAddress
+          )
+        ) {
+          return cacheMissResponse("Cached proxy implementation is outdated.");
+        }
+      } catch (error) {
+        console.warn(
+          "Proxy staleness check failed, serving cached layout:",
+          error
+        );
+      }
+    }
+
+    return jsonResponse(
+      {
         storageLayout: entry.storageLayout,
         contractName: entry.contractName,
         sourceAddress: entry.sourceAddress,
         proxyInfo: entry.proxyInfo,
-      }),
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          "Cache-Control": "s-maxage=86400, stale-while-revalidate",
-        },
-      }
+      },
+      200,
+      entry.proxyInfo ? "no-store" : "s-maxage=86400, stale-while-revalidate"
     );
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
     console.error(errorMessage);
-    return new Response(JSON.stringify({ message: errorMessage }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ message: errorMessage }, 500);
   }
+}
+
+function cacheMissResponse(message = "Storage layout not cached.") {
+  return jsonResponse({ message }, 404);
+}
+
+function jsonResponse(body, status = 200, cacheControl = undefined) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...(cacheControl ? { "Cache-Control": cacheControl } : {}),
+    },
+  });
 }

--- a/api/get_cached_storage_layout.js
+++ b/api/get_cached_storage_layout.js
@@ -4,6 +4,7 @@ import {
   isAddress,
   sameAddress,
 } from "./_lib/eip1967.js";
+import { VALUE_METADATA_VERSION } from "./_lib/value-metadata-version.js";
 
 export async function POST(request) {
   try {
@@ -23,6 +24,16 @@ export async function POST(request) {
 
     if (!entry?.storageLayout) {
       return cacheMissResponse();
+    }
+    // Entries cached before on-chain value decoding existed (or by an older
+    // version of it) won't have the types[].encoding/base/key/value fields
+    // that decoding needs - treat a version mismatch as a cache miss so the
+    // wizard regenerates and re-caches in the current shape, rather than
+    // silently degrading every row to "unsupported" forever.
+    if (entry.valueMetadataVersion !== VALUE_METADATA_VERSION) {
+      return cacheMissResponse(
+        "Cached storage layout predates on-chain value decoding support."
+      );
     }
 
     // Proxies can be upgraded after their layout was cached, which would

--- a/api/get_eip1967_proxy_info.js
+++ b/api/get_eip1967_proxy_info.js
@@ -1,0 +1,39 @@
+import {
+  getEip1967ProxyInfo,
+  isAddress,
+} from "./_lib/eip1967.js";
+
+export async function POST(request) {
+  try {
+    const { chainId, address } = await request.json();
+
+    if (!chainId || !address) {
+      return jsonResponse(
+        { message: "Chain ID and address are required." },
+        400
+      );
+    }
+    if (!/^\d+$/.test(String(chainId)) || !isAddress(address)) {
+      return jsonResponse({ message: "Invalid chain ID or address." }, 400);
+    }
+
+    return jsonResponse(
+      await getEip1967ProxyInfo(Number(chainId), address)
+    );
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    console.error(errorMessage);
+    return jsonResponse({ message: errorMessage }, 500);
+  }
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "s-maxage=300, stale-while-revalidate",
+    },
+  });
+}

--- a/api/get_storage_values.js
+++ b/api/get_storage_values.js
@@ -1,0 +1,87 @@
+import { isAddress } from "./_lib/eip1967.js";
+import { getRpcUrls, createFallbackProvider } from "./_lib/rpc.js";
+
+// Bounds the RPC fan-out per request (each entry is one eth_getStorageAt
+// call, run in parallel) so a pathological request can't run past the
+// serverless function timeout.
+const MAX_SLOTS_PER_REQUEST = 400;
+
+export async function POST(request) {
+  try {
+    const { chainId, address, slots } = await request.json();
+
+    if (!chainId || !address || !Array.isArray(slots) || slots.length === 0) {
+      return jsonResponse(
+        { message: "Chain ID, address and a non-empty slot list are required." },
+        400
+      );
+    }
+    if (!/^\d+$/.test(String(chainId)) || !isAddress(address)) {
+      return jsonResponse({ message: "Invalid chain ID or address." }, 400);
+    }
+    if (slots.length > MAX_SLOTS_PER_REQUEST) {
+      return jsonResponse(
+        { message: `Too many slots requested (max ${MAX_SLOTS_PER_REQUEST}).` },
+        400
+      );
+    }
+
+    let normalizedSlots;
+    try {
+      normalizedSlots = slots.map((slot) => [slot, toSlotHex(slot)]);
+    } catch {
+      return jsonResponse({ message: "Invalid slot value." }, 400);
+    }
+
+    const rpcUrls = await getRpcUrls(Number(chainId));
+    if (rpcUrls.length === 0) {
+      return jsonResponse(
+        { message: `No public HTTPS RPC URL found for chain ID ${chainId}.` },
+        502
+      );
+    }
+
+    const provider = createFallbackProvider(rpcUrls);
+    const values = {};
+    await Promise.all(
+      normalizedSlots.map(async ([original, hex]) => {
+        values[original] = await provider.send("eth_getStorageAt", [
+          address,
+          hex,
+          "latest",
+        ]);
+      })
+    );
+
+    return jsonResponse({ values }, 200, "no-store");
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    console.error(errorMessage);
+    return jsonResponse({ message: errorMessage }, 500);
+  }
+}
+
+// Slots are given as decimal or 0x-hex strings representing a uint256 (either
+// a storage slot index, or a keccak256-derived pointer for dynamic
+// bytes/string data). Throws on anything else.
+function toSlotHex(slot) {
+  if (typeof slot !== "string" && typeof slot !== "number") {
+    throw new Error("Invalid slot value.");
+  }
+  const value = BigInt(slot);
+  if (value < 0n || value > (1n << 256n) - 1n) {
+    throw new Error("Slot out of range.");
+  }
+  return `0x${value.toString(16).padStart(64, "0")}`;
+}
+
+function jsonResponse(body, status = 200, cacheControl = undefined) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...(cacheControl ? { "Cache-Control": cacheControl } : {}),
+    },
+  });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,8 @@ function App() {
               storageLayout: data.storageLayout,
               chainId: Number(chainId),
               address: address ? address : undefined,
+              sourceAddress: data.sourceAddress,
+              proxyInfo: data.proxyInfo,
             },
           ]);
         } else {
@@ -130,6 +132,8 @@ function App() {
                     id={storageLayout.id}
                     chainId={storageLayout.chainId}
                     address={storageLayout.address}
+                    sourceAddress={storageLayout.sourceAddress}
+                    proxyInfo={storageLayout.proxyInfo}
                   />
                 ))}
               </div>

--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -149,7 +149,7 @@ export default function AnalyzeWizardButton({
   }, [chains, initialChainId]);
 
   // Address management with zod validation
-  const [address, setAddress] = useState<string | undefined>(initialAddress);
+  const [address, setAddress] = useState<string>(initialAddress ?? "");
   const [sourceAddress, setSourceAddress] = useState<string | undefined>(
     initialAddress
   );
@@ -214,7 +214,7 @@ export default function AnalyzeWizardButton({
     setCompiledContracts({});
     setChainsPopoverOpen(false);
     setChainName(undefined);
-    setAddress(undefined);
+    setAddress("");
     setSourceAddress(undefined);
     setProxyInfo(undefined);
     setCompilerBinary("");

--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -249,7 +249,15 @@ export default function AnalyzeWizardButton({
       return;
     }
 
-    const detectedProxyInfo = await fetchEip1967ProxyInfo(chainId, address);
+    // Proxy detection is a convenience: if it fails (no public RPC for the
+    // chain, RPCs down, ...) fall back to analyzing the address as-is
+    // rather than blocking the whole flow.
+    let detectedProxyInfo: Eip1967ProxyInfo | undefined;
+    try {
+      detectedProxyInfo = await fetchEip1967ProxyInfo(chainId, address);
+    } catch (error) {
+      console.warn("EIP-1967 proxy detection failed:", error);
+    }
     const sourcifyAddress = detectedProxyInfo?.implementationAddress ?? address;
     setProxyInfo(detectedProxyInfo);
     setSourceAddress(sourcifyAddress);
@@ -625,27 +633,20 @@ export default function AnalyzeWizardButton({
     chainId: number,
     address: string
   ): Promise<Eip1967ProxyInfo | undefined> {
-    try {
-      const response = await fetch("/api/get_eip1967_proxy_info", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ chainId, address }),
-      });
-      if (!response.ok) {
-        console.warn(
-          "EIP-1967 proxy detection failed:",
-          (await response.json()).message
-        );
-        return undefined;
-      }
-
-      const proxyInfoResponse =
-        (await response.json()) as Eip1967ProxyInfoResponse;
-      return proxyInfoResponse.proxyInfo;
-    } catch (error) {
-      console.warn("EIP-1967 proxy detection failed:", error);
-      return undefined;
+    const response = await fetch("/api/get_eip1967_proxy_info", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chainId, address }),
+    });
+    if (!response.ok) {
+      throw new Error(
+        (await response.json()).message ?? "EIP-1967 proxy detection failed."
+      );
     }
+
+    const proxyInfoResponse =
+      (await response.json()) as Eip1967ProxyInfoResponse;
+    return proxyInfoResponse.proxyInfo;
   }
 
   return (
@@ -775,7 +776,7 @@ export default function AnalyzeWizardButton({
               from sourcify
               {proxyInfo && (
                 <span className="block text-green-500 mt-2">
-                  EIP-1967 proxy detected. Fetching the sources of the active
+                  Upgradeable proxy detected. Fetching the sources of the active
                   implementation at {proxyInfo.implementationAddress}.
                 </span>
               )}
@@ -909,7 +910,7 @@ export default function AnalyzeWizardButton({
               contract to load storage layout.
               {proxyInfo && (
                 <span className="block text-green-500 mt-2">
-                  {address} is an EIP-1967 proxy: these contracts come from its
+                  {address} is an upgradeable proxy: these contracts come from its
                   active implementation at {proxyInfo.implementationAddress}.
                 </span>
               )}

--- a/src/components/AnalyzeWizardButton.tsx
+++ b/src/components/AnalyzeWizardButton.tsx
@@ -51,6 +51,10 @@ import type { SolcInput, SolcOutput } from "@openzeppelin/upgrades-core";
 import type { Dispatch, SetStateAction } from "react";
 import type { StorageLayout } from "@openzeppelin/upgrades-core";
 import type { ReactNode } from "react";
+import type {
+  Eip1967ProxyInfo,
+  Eip1967ProxyInfoResponse,
+} from "@/lib/eip1967";
 
 interface AnalyzeWizardButtonProps {
   setParentDialogOpen?: Dispatch<SetStateAction<boolean>>;
@@ -146,6 +150,12 @@ export default function AnalyzeWizardButton({
 
   // Address management with zod validation
   const [address, setAddress] = useState<string | undefined>(initialAddress);
+  const [sourceAddress, setSourceAddress] = useState<string | undefined>(
+    initialAddress
+  );
+  const [proxyInfo, setProxyInfo] = useState<Eip1967ProxyInfo | undefined>(
+    undefined
+  );
   const [addressError, setAddressError] = useState<string | undefined>(
     undefined
   );
@@ -205,6 +215,8 @@ export default function AnalyzeWizardButton({
     setChainsPopoverOpen(false);
     setChainName(undefined);
     setAddress(undefined);
+    setSourceAddress(undefined);
+    setProxyInfo(undefined);
     setCompilerBinary("");
     setSolcInput(undefined);
     setSolcOutput(undefined);
@@ -232,8 +244,18 @@ export default function AnalyzeWizardButton({
     setWizardStep(WizardStep.FETCHING);
 
     const chainId = chains.find((_chain) => _chain.name === chainName)?.chainId;
+    if (!chainId || !address) {
+      setWizardStep(WizardStep.SELECT_ADDRESS);
+      return;
+    }
+
+    const detectedProxyInfo = await fetchEip1967ProxyInfo(chainId, address);
+    const sourcifyAddress = detectedProxyInfo?.implementationAddress ?? address;
+    setProxyInfo(detectedProxyInfo);
+    setSourceAddress(sourcifyAddress);
+
     const response = await fetch(
-      `https://sourcify.dev/server/v2/contract/${chainId}/${address}?fields=stdJsonInput,compilation`,
+      `https://sourcify.dev/server/v2/contract/${chainId}/${sourcifyAddress}?fields=stdJsonInput,compilation`,
       {
         method: "GET",
       }
@@ -241,9 +263,12 @@ export default function AnalyzeWizardButton({
     if (!response.ok) {
       if (response.status === 404) {
         const data = await response.json();
+        const targetDescription = detectedProxyInfo
+          ? `Implementation ${sourcifyAddress} for proxy ${address}`
+          : `Contract at ${data.address}`;
         setFetchArtifactsError(
           <>
-            {`Contract at ${data.address} on chain id ${data.chainId} not verified on Sourcify. Please verify your contract using the `}
+            {`${targetDescription} on chain id ${data.chainId} not verified on Sourcify. Please verify your contract using the `}
             <a
               href="https://verify.sourcify.dev/"
               target="_blank"
@@ -504,6 +529,12 @@ export default function AnalyzeWizardButton({
   async function handleLoadStorageLayout() {
     setWizardStep(WizardStep.LOADING);
     if (!selectedContract || !solcInput || !solcOutput) return;
+    const displaySourceAddress =
+      sourceAddress &&
+      address &&
+      sourceAddress.toLowerCase() !== address.toLowerCase()
+        ? sourceAddress
+        : undefined;
 
     // Extract storage layout using backend
     let storageLayout: StorageLayout | undefined = undefined;
@@ -520,6 +551,7 @@ export default function AnalyzeWizardButton({
           contractName: selectedContract,
           chainId: chains.find((_chain) => _chain.name === chainName)?.chainId,
           address: address,
+          sourceAddress: sourceAddress,
         })
       );
       const _compressedBodyRequest = _brotli.compress(
@@ -557,7 +589,9 @@ export default function AnalyzeWizardButton({
             id: 0,
             storageLayout: storageLayout!,
             chainId: chains.find((_chain) => _chain.name === chainName)?.chainId,
-            address: address
+            address: address,
+            sourceAddress: displaySourceAddress,
+            proxyInfo: proxyInfo,
           },
           ...prevLayouts.slice(triggerVisualizerId + 1),
         ];
@@ -572,7 +606,9 @@ export default function AnalyzeWizardButton({
           id: 0,
           storageLayout: storageLayout!,
           chainId: chains.find((_chain) => _chain.name === chainName)?.chainId,
-          address: address
+          address: address,
+          sourceAddress: displaySourceAddress,
+          proxyInfo: proxyInfo,
         },
       ];
     });
@@ -582,6 +618,33 @@ export default function AnalyzeWizardButton({
     // Close parent dialog if exist
     if (setParentDialogOpen) {
       setParentDialogOpen(false);
+    }
+  }
+
+  async function fetchEip1967ProxyInfo(
+    chainId: number,
+    address: string
+  ): Promise<Eip1967ProxyInfo | undefined> {
+    try {
+      const response = await fetch("/api/get_eip1967_proxy_info", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chainId, address }),
+      });
+      if (!response.ok) {
+        console.warn(
+          "EIP-1967 proxy detection failed:",
+          (await response.json()).message
+        );
+        return undefined;
+      }
+
+      const proxyInfoResponse =
+        (await response.json()) as Eip1967ProxyInfoResponse;
+      return proxyInfoResponse.proxyInfo;
+    } catch (error) {
+      console.warn("EIP-1967 proxy detection failed:", error);
+      return undefined;
     }
   }
 
@@ -710,6 +773,12 @@ export default function AnalyzeWizardButton({
             >
               Please wait while your contract source files are being fetched
               from sourcify
+              {proxyInfo && (
+                <span className="block text-green-500 mt-2">
+                  EIP-1967 proxy detected. Fetching the sources of the active
+                  implementation at {proxyInfo.implementationAddress}.
+                </span>
+              )}
             </DialogDescription>
           </DialogHeader>
           <div className="flex items-center justify-center">
@@ -733,10 +802,10 @@ export default function AnalyzeWizardButton({
               {
                 //@ts-expect-error optimizer is not typed in SolcInput settings
                 solcInput?.settings?.optimizer?.enabled && (
-                  <p>
+                  <span className="block">
                     Compilation might take a while because the optimizer is
                     enabled.
-                  </p>
+                  </span>
                 )
               }
             </DialogDescription>
@@ -838,6 +907,12 @@ export default function AnalyzeWizardButton({
             >
               The contracts have been compiled successfully. Please select a
               contract to load storage layout.
+              {proxyInfo && (
+                <span className="block text-green-500 mt-2">
+                  {address} is an EIP-1967 proxy: these contracts come from its
+                  active implementation at {proxyInfo.implementationAddress}.
+                </span>
+              )}
             </DialogDescription>
           </DialogHeader>
           <div className="overflow-hidden">

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useContext, useMemo, useState } from "react";
+import { Fragment, useContext, useEffect, useMemo, useState } from "react";
 import { Code2, Code, Share, X, Cross, TriangleAlert, Braces } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -53,6 +53,19 @@ const SLOT_ZERO =
 
 const truncateAddress = (value: string) =>
   `${value.slice(0, 10)}...${value.slice(-8)}`;
+
+const storageLayoutScopeIds = new WeakMap<StorageLayout, number>();
+let nextStorageLayoutScopeId = 0;
+
+function getStorageLayoutScopeId(storageLayout: StorageLayout) {
+  let id = storageLayoutScopeIds.get(storageLayout);
+  if (id === undefined) {
+    id = nextStorageLayoutScopeId;
+    nextStorageLayoutScopeId += 1;
+    storageLayoutScopeIds.set(storageLayout, id);
+  }
+  return id;
+}
 
 // A type's `members` is either struct fields or enum value names (plain
 // strings) - only the former has its own slot/offset layout to unwrap.
@@ -338,6 +351,9 @@ export default function StorageVisualizer({
     selectedTab === ROOT_LAYOUT_TAB || storageLayout.namespaces?.[selectedTab]
       ? selectedTab
       : ROOT_LAYOUT_TAB;
+  const valueScopeKey = `${getStorageLayoutScopeId(storageLayout)}|${
+    chainId ?? "local"
+  }|${address ?? ""}`;
 
   function handleCopyJson(mode: "full" | "tab" | "all") {
     // Optimistic feedback: the tooltip must already read "Copied!" when the
@@ -386,13 +402,18 @@ export default function StorageVisualizer({
     | { status: "loaded"; rawSlotHex: string; decoded: DecodedValue | DecodedValue[] };
   const [valueState, setValueState] = useState<Record<string, ValueFetchState>>({});
 
+  useEffect(() => {
+    setExpandedItems(new Set());
+    setValueState({});
+  }, [valueScopeKey]);
+
   function itemKeyFor(
     layoutName: string,
     item: ItemWrapper,
     rowIndex: number,
     itemIndex: number
   ) {
-    return `${layoutName}|${storageLayout.types[item.item.type].label}|${item.item.label}|${rowIndex}|${itemIndex}`;
+    return `${valueScopeKey}|${layoutName}|${storageLayout.types[item.item.type].label}|${item.item.label}|${rowIndex}|${itemIndex}`;
   }
 
   function handleToggleExpand(

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from "react";
+import { Fragment, useContext, useMemo, useState } from "react";
 import { Code2, Code, Share, X, Cross, TriangleAlert, Braces } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -42,9 +42,13 @@ import type {
   TypeItemMembers,
   StructMember,
 } from "@openzeppelin/upgrades-core";
+import type { Eip1967ProxyInfo } from "@/lib/eip1967";
 
 const SLOT_ZERO =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+const truncateAddress = (value: string) =>
+  `${value.slice(0, 10)}...${value.slice(-8)}`;
 
 // A type's `members` is either struct fields or enum value names (plain
 // strings) - only the former has its own slot/offset layout to unwrap.
@@ -263,6 +267,8 @@ export interface StorageVisualizerProps {
   storageLayout: StorageLayout;
   chainId: number | undefined;
   address: string | undefined;
+  sourceAddress?: string;
+  proxyInfo?: Eip1967ProxyInfo;
 }
 
 export default function StorageVisualizer({
@@ -271,6 +277,8 @@ export default function StorageVisualizer({
   storageLayout,
   chainId,
   address,
+  sourceAddress,
+  proxyInfo,
 }: StorageVisualizerProps) {
   // Global context
   const storageLayoutsContext = useContext(StorageLayoutsContext);
@@ -311,6 +319,8 @@ export default function StorageVisualizer({
               contractName,
               chainId,
               address,
+              sourceAddress,
+              proxyInfo,
               storageLayout,
               namespace:
                 activeTab === ROOT_LAYOUT_TAB ? undefined : activeTab,
@@ -396,6 +406,8 @@ export default function StorageVisualizer({
     return wrappers;
   }, [storageLayout]);
 
+  const sourcifyAddress = sourceAddress ?? address;
+
   return (
     <Card className="bg-black border-green-500 md:mb-4 overflow-hidden relative py-0 gap-0 h-full w-full transition-all duration-500 ease-in-out">
       {/* Upper Bar */}
@@ -404,10 +416,11 @@ export default function StorageVisualizer({
           <Code2 className="text-green-500 h-4 w-4" />
           <span className="text-green-500 text-sm font-bold">
             {chainId !== undefined && address !== undefined
-              ? `${contractName} (Addr: ${address.slice(
-                  0,
-                  10
-                )}...${address.slice(-8)} | Chain Id: ${chainId})`
+              ? `${contractName} (${
+                  proxyInfo
+                    ? `Proxy: ${truncateAddress(address)} | Impl: ${truncateAddress(proxyInfo.implementationAddress)}`
+                    : `Addr: ${truncateAddress(address)}`
+                } | Chain Id: ${chainId})`
               : contractName}
           </span>
         </div>
@@ -421,7 +434,7 @@ export default function StorageVisualizer({
                     size="icon"
                     onClick={() =>
                       window.open(
-                        `https://repo.sourcify.dev/${chainId.toString()}/${address}`,
+                        `https://repo.sourcify.dev/${chainId.toString()}/${sourcifyAddress}`,
                         "_blank"
                       )
                     }
@@ -431,7 +444,9 @@ export default function StorageVisualizer({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
-                  View code on Sourcify.eth
+                  {proxyInfo
+                    ? "View implementation code on Sourcify.eth"
+                    : "View code on Sourcify.eth"}
                 </TooltipContent>
               </Tooltip>
 
@@ -575,6 +590,30 @@ export default function StorageVisualizer({
         </div>
       </div>
 
+      {proxyInfo && (
+        <div className="border-b border-green-500/30 bg-green-900/10 px-4 py-2 text-[11px] text-green-500">
+          <span className="font-bold">EIP-1967 proxy detected.</span>{" "}
+          <span>Proxy storage: {truncateAddress(proxyInfo.proxyAddress)}</span>
+          <span className="mx-2">|</span>
+          <span>
+            Implementation layout:{" "}
+            {truncateAddress(proxyInfo.implementationAddress)}
+          </span>
+          {proxyInfo.beaconAddress && (
+            <>
+              <span className="mx-2">|</span>
+              <span>Beacon: {truncateAddress(proxyInfo.beaconAddress)}</span>
+            </>
+          )}
+          {proxyInfo.adminAddress && (
+            <>
+              <span className="mx-2">|</span>
+              <span>Admin: {truncateAddress(proxyInfo.adminAddress)}</span>
+            </>
+          )}
+        </div>
+      )}
+
       {/* Tabs*/}
       <Tabs value={activeTab} onValueChange={setSelectedTab} className="w-full">
         <div
@@ -589,7 +628,7 @@ export default function StorageVisualizer({
         >
           <TabsList className="bg-transparent h-9 flex items-center whitespace-nowrap">
             {storageLayouts.map((layout) => (
-              <>
+              <Fragment key={layout.name}>
                 <TabsTrigger
                   value={layout.name}
                   className="text-green-500 data-[state=active]:bg-green-900/30 data-[state=active]:text-green-500 data-[state=active]:shadow-none rounded-none border-r"
@@ -597,24 +636,31 @@ export default function StorageVisualizer({
                   {layout.name}
                 </TabsTrigger>
                 <div className="w-px h-6 bg-green-500 mx-2 self-center" />
-              </>
+              </Fragment>
             ))}
           </TabsList>
         </div>
 
         {/*Content */}
         {storageLayouts.map((layout, index) => (
-          <TabsContent value={layout.name} className="mt-0">
+          <TabsContent key={layout.name} value={layout.name} className="mt-0">
             {layout.baseSlot !== undefined && (
               <div className="px-4 pb-2 text-green-500 text-[8px] md:text-[11px]">
                 base slot: {layout.baseSlot}
               </div>
             )}
             {layout.slots.length === 0 && (
-              <div className="flex items-center justify-center gap-2 px-4 pb-2 my-5 text-green-500">
-                <TriangleAlert className="h-4 w-4" />
-                <span className="text-center">
-                  {layout.name} has no storage items defined.
+              <div className="flex flex-col items-center gap-1 px-4 pb-2 my-5 text-green-500">
+                <div className="flex items-center justify-center gap-2">
+                  <TriangleAlert className="h-4 w-4" />
+                  <span className="text-center">
+                    {layout.name} has no storage items defined.
+                  </span>
+                </div>
+                <span className="text-center text-green-500/60 text-xs">
+                  The contract may only use constants/immutables, or keep its
+                  state in unstructured storage (manually computed slots),
+                  which the compiler's storage layout cannot describe.
                 </span>
               </div>
             )}

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -44,6 +44,9 @@ import type {
 } from "@openzeppelin/upgrades-core";
 import { proxyKindLabel } from "@/lib/eip1967";
 import type { Eip1967ProxyInfo } from "@/lib/eip1967";
+import { fetchStorageValues } from "@/lib/storage-values";
+import { resolveStorageValue } from "@/lib/decode-storage-value";
+import type { DecodedValue, RawTypes } from "@/lib/decode-storage-value";
 
 const SLOT_ZERO =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
@@ -93,6 +96,14 @@ interface ItemWrapper {
   color: string;
   width: number;
   offset: number;
+  // Byte-precision counterparts of width/offset (which are percentages, for
+  // CSS) - needed to fetch and decode this segment's on-chain value.
+  widthBytes: number;
+  offsetBytes: number;
+  // How many bytes of the item's *own* value were already shown by earlier
+  // rows (0 unless this is a continuation row of a multi-slot item). Lets a
+  // fixed-array row figure out which element indices its bytes cover.
+  byteRangeStart: number;
 }
 
 // A single displayed row. Usually one row is one slot (label is that slot
@@ -102,6 +113,11 @@ interface ItemWrapper {
 interface SlotRow {
   items: ItemWrapper[];
   label: string;
+  // Relative starting slot this row represents, and how many slots it spans
+  // (>1 only for a collapsed row) - used to compute the absolute on-chain
+  // slot to read when a segment is clicked.
+  slotIndex: number;
+  slotSpan: number;
 }
 
 interface StorageLayoutWrapper {
@@ -175,6 +191,11 @@ function getStorageLayoutWrapper(
       }
     }
 
+    // Tracks, per item, how many bytes of its own value have already been
+    // shown by earlier rows - lets a fixed-array row figure out which
+    // element indices its own bytes cover. Reset per wrapper build.
+    const consumedBytes = new WeakMap<StorageItem, number>();
+
     let overflowBytes = 0;
     for (let i = 0; i <= maxSlot; i++) {
       // copy: the overflow handling below unshifts into this array
@@ -200,9 +221,14 @@ function getStorageLayoutWrapper(
                 color: idToColor[`${item.contract}:${item.label}`],
                 width: 100,
                 offset: 0,
+                widthBytes: Math.min(itemNumberOfBytes, 32),
+                offsetBytes: 0,
+                byteRangeStart: 0,
               },
             ],
             label: `${i}–${endSlot}`,
+            slotIndex: i,
+            slotSpan: itemSlotSpan,
           });
           i = endSlot;
           continue;
@@ -235,11 +261,17 @@ function getStorageLayoutWrapper(
             if (width > 32) {
               width = 32;
             }
+            const offsetBytes = Number(item.offset);
+            const byteRangeStart = consumedBytes.get(item) ?? 0;
+            consumedBytes.set(item, byteRangeStart + width);
             const wrappedItem: ItemWrapper = {
               item: item,
               color: idToColor[`${item.contract}:${item.label}`],
               width: Number(width) * 3.125, // 100%/32Bytes = 3.125
-              offset: Number(item.offset) * 3.125, // 100%/32Bytes = 3.125
+              offset: offsetBytes * 3.125, // 100%/32Bytes = 3.125
+              widthBytes: width,
+              offsetBytes,
+              byteRangeStart,
             };
             return wrappedItem;
           })
@@ -252,7 +284,7 @@ function getStorageLayoutWrapper(
       } else {
         overflowBytes = 0;
       }
-      slots.push({ items: slotItemsWrapped, label: String(i) });
+      slots.push({ items: slotItemsWrapped, label: String(i), slotIndex: i, slotSpan: 1 });
     }
   }
   return {
@@ -342,33 +374,142 @@ export default function StorageVisualizer({
     });
   }
 
-  // Helpers to manage pinnable tooltips, each tooltip stare is tracked in a key-value object where the key is LayoutName|TypeLabel|ItemLabel
-  const [pinnedTooltips, setPinnedTooltips] = useState<Record<string, boolean>>(
-    {}
-  );
-  const [visibleTooltips, setVisibleTooltips] = useState<
-    Record<string, boolean>
-  >({});
+  // Clicking a slot segment expands an inline block showing its on-chain
+  // value (fetched on demand, only for the clicked slot). Hovering still
+  // shows the plain type|label tooltip, unaffected by any of this - each
+  // item's key is LayoutName|TypeLabel|ItemLabel|RowIndex|ItemIndex.
+  const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
+  type ValueFetchState =
+    | { status: "loading" }
+    | { status: "error"; message: string }
+    | { status: "unavailable"; message: string }
+    | { status: "loaded"; rawSlotHex: string; decoded: DecodedValue | DecodedValue[] };
+  const [valueState, setValueState] = useState<Record<string, ValueFetchState>>({});
 
-  function handlePinTooltip(key: string) {
-    const willBePinned = !pinnedTooltips[key];
-    setPinnedTooltips((prev) => ({
-      ...prev,
-      [key]: willBePinned,
-    }));
-    if (willBePinned) {
-      setVisibleTooltips((prev) => ({
-        ...prev,
-        [key]: true,
-      }));
-    }
+  function itemKeyFor(
+    layoutName: string,
+    item: ItemWrapper,
+    rowIndex: number,
+    itemIndex: number
+  ) {
+    return `${layoutName}|${storageLayout.types[item.item.type].label}|${item.item.label}|${rowIndex}|${itemIndex}`;
   }
 
-  function handleOpenTooltip(key: string, openFromInteraction: boolean) {
-    setVisibleTooltips((prevVisible) => ({
-      ...prevVisible,
-      [key]: openFromInteraction,
-    }));
+  function handleToggleExpand(
+    itemKey: string,
+    row: SlotRow,
+    item: ItemWrapper,
+    layout: StorageLayoutWrapper
+  ) {
+    const wasExpanded = expandedItems.has(itemKey);
+    setExpandedItems((prev) => {
+      const next = new Set(prev);
+      if (wasExpanded) {
+        next.delete(itemKey);
+      } else {
+        next.add(itemKey);
+      }
+      return next;
+    });
+    if (wasExpanded || valueState[itemKey]) return;
+
+    if (chainId === undefined || address === undefined) {
+      setValueState((prev) => ({
+        ...prev,
+        [itemKey]: {
+          status: "unavailable",
+          message: "No on-chain address associated with this layout.",
+        },
+      }));
+      return;
+    }
+    if (row.slotSpan > 1) {
+      setValueState((prev) => ({
+        ...prev,
+        [itemKey]: {
+          status: "unavailable",
+          message: "Collapsed multi-slot range — values are not resolved.",
+        },
+      }));
+      return;
+    }
+
+    setValueState((prev) => ({ ...prev, [itemKey]: { status: "loading" } }));
+    void (async () => {
+      try {
+        const baseSlot = layout.baseSlot ? BigInt(layout.baseSlot) : 0n;
+        const absoluteSlot = baseSlot + BigInt(row.slotIndex);
+        const slotKey = absoluteSlot.toString();
+        const values = await fetchStorageValues(chainId, address, [slotKey]);
+        const rawSlotHex = values[slotKey];
+        if (rawSlotHex === undefined) {
+          throw new Error("No value returned for this slot.");
+        }
+        const types = storageLayout.types as unknown as RawTypes;
+        const type = types[item.item.type];
+        const decoded = await resolveStorageValue(
+          type,
+          types,
+          item.offsetBytes,
+          item.widthBytes,
+          item.byteRangeStart,
+          absoluteSlot,
+          rawSlotHex,
+          (slots) => fetchStorageValues(chainId, address, slots)
+        );
+        setValueState((prev) => ({
+          ...prev,
+          [itemKey]: { status: "loaded", rawSlotHex, decoded },
+        }));
+      } catch (error) {
+        setValueState((prev) => ({
+          ...prev,
+          [itemKey]: {
+            status: "error",
+            message: error instanceof Error ? error.message : "Failed to fetch value.",
+          },
+        }));
+      }
+    })();
+  }
+
+  function renderValueBlock(state: ValueFetchState | undefined) {
+    if (!state) return null;
+    if (state.status === "loading") {
+      return <span className="text-green-500/70 italic">Fetching…</span>;
+    }
+    if (state.status === "error") {
+      return <span className="text-red-400">Error: {state.message}</span>;
+    }
+    if (state.status === "unavailable") {
+      return <span className="text-green-500/50 italic">{state.message}</span>;
+    }
+    const decoded = state.decoded;
+    return (
+      <div className="flex flex-col gap-0.5">
+        <div className="font-mono break-all text-green-500/80">
+          hex: {state.rawSlotHex}
+        </div>
+        {Array.isArray(decoded) ? (
+          decoded.map((element) => (
+            <div key={element.index}>
+              <span className="text-green-500/70">[{element.index}]</span>{" "}
+              <span className="font-mono">{element.display}</span>
+              {element.note && (
+                <span className="text-green-500/50 italic ml-1">{element.note}</span>
+              )}
+            </div>
+          ))
+        ) : (
+          <div>
+            <span className="font-mono">{decoded.display}</span>
+            {decoded.note && (
+              <span className="text-green-500/50 italic ml-1">{decoded.note}</span>
+            )}
+          </div>
+        )}
+      </div>
+    );
   }
 
   // Build the per-tab wrapper array once per layout: controlled Tabs and
@@ -671,62 +812,80 @@ export default function StorageVisualizer({
               key={index}
               className=" px-4 pb-4 overflow-x-auto text-green-500 text-sm leading-relaxed"
             >
-              {layout.slots.map((row, rowIndex) => (
-                <div key={rowIndex} className=" flex flex-row my-0.5 ">
-                  <div className="min-w-5 shrink-0 pr-1 text-[11px]">
-                    {row.label}
-                  </div>
-                  <div className=" h-[1.2rem] w-full relative ">
-                    {row.items.map((item, itemIndex) => {
-                      // Include the row/segment position in the key: an
-                      // item spanning multiple slots (e.g. uint256[80])
-                      // repeats the same label/type on every row it
-                      // occupies, so without this each segment would share
-                      // one tooltip state and all open together on hover.
-                      const tooltipKey = `${layout.name}|${
-                        storageLayout?.types[item.item.type].label
-                      }|${item.item.label}|${rowIndex}|${itemIndex}`;
-                      return (
-                        <div key={itemIndex} className=" flex flex-col">
-                          <Tooltip
-                            open={Boolean(
-                              visibleTooltips[tooltipKey] ||
-                                pinnedTooltips[tooltipKey]
-                            )}
-                            onOpenChange={(isOpen) =>
-                              handleOpenTooltip(tooltipKey, isOpen)
-                            }
-                          >
-                            <TooltipTrigger
-                              asChild
-                              onClick={() => {
-                                handlePinTooltip(tooltipKey);
-                              }}
+              {layout.slots.map((row, rowIndex) => {
+                const expandedInRow = row.items
+                  .map((item, itemIndex) => ({ item, itemIndex }))
+                  .filter(({ item, itemIndex }) =>
+                    expandedItems.has(itemKeyFor(layout.name, item, rowIndex, itemIndex))
+                  );
+                return (
+                  <div key={rowIndex} className="flex flex-col my-0.5">
+                    <div className="flex flex-row">
+                      <div className="min-w-5 shrink-0 pr-1 text-[11px]">
+                        {row.label}
+                      </div>
+                      <div className=" h-[1.2rem] w-full relative ">
+                        {row.items.map((item, itemIndex) => {
+                          // Include the row/segment position in the key: an
+                          // item spanning multiple slots (e.g. uint256[80])
+                          // repeats the same label/type on every row it
+                          // occupies, so without this each segment would
+                          // share one state and all expand together.
+                          const itemKey = itemKeyFor(layout.name, item, rowIndex, itemIndex);
+                          return (
+                            <div key={itemIndex} className=" flex flex-col">
+                              <Tooltip>
+                                <TooltipTrigger
+                                  asChild
+                                  onClick={() =>
+                                    handleToggleExpand(itemKey, row, item, layout)
+                                  }
+                                >
+                                  <div
+                                    style={{
+                                      width: `${item.width}%`,
+                                      left: `${item.offset}%`,
+                                      backgroundColor: item.color,
+                                    }}
+                                    className="h-full absolute border border-green-500 cursor-pointer"
+                                  />
+                                </TooltipTrigger>
+                                <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
+                                  <span>
+                                    {`${
+                                      storageLayout?.types[item.item.type].label
+                                    } | ${item.item.label}`}
+                                  </span>
+                                </TooltipContent>
+                              </Tooltip>
+                            </div>
+                          );
+                        })}
+                      </div>
+                      <div className="h-[2px]" />
+                    </div>
+                    {expandedInRow.length > 0 && (
+                      <div className="ml-5 flex flex-col gap-1 pb-1 text-[10px] md:text-[11px]">
+                        {expandedInRow.map(({ item, itemIndex }) => {
+                          const itemKey = itemKeyFor(layout.name, item, rowIndex, itemIndex);
+                          return (
+                            <div
+                              key={itemIndex}
+                              className="border border-green-500/30 rounded bg-green-950/20 px-2 py-1"
                             >
-                              <div
-                                style={{
-                                  width: `${item.width}%`,
-                                  left: `${item.offset}%`,
-                                  backgroundColor: item.color,
-                                }}
-                                className="h-full absolute border border-green-500"
-                              />
-                            </TooltipTrigger>
-                            <TooltipContent className="bg-black border-green-500 border text-green-500 px-3 py-1 rounded-md shadow-md text-xs transition-colors duration-200">
-                              <span>
-                                {`${
-                                  storageLayout?.types[item.item.type].label
-                                } | ${item.item.label}`}
-                              </span>
-                            </TooltipContent>
-                          </Tooltip>
-                        </div>
-                      );
-                    })}
+                              <div className="text-green-500/70">
+                                {storageLayout.types[item.item.type].label} ·{" "}
+                                {item.item.label}
+                              </div>
+                              {renderValueBlock(valueState[itemKey])}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
                   </div>
-                  <div className="h-[2px]" />
-                </div>
-              ))}
+                );
+              })}
             </div>
           </TabsContent>
         ))}

--- a/src/components/StorageVisualizer.tsx
+++ b/src/components/StorageVisualizer.tsx
@@ -42,6 +42,7 @@ import type {
   TypeItemMembers,
   StructMember,
 } from "@openzeppelin/upgrades-core";
+import { proxyKindLabel } from "@/lib/eip1967";
 import type { Eip1967ProxyInfo } from "@/lib/eip1967";
 
 const SLOT_ZERO =
@@ -592,7 +593,9 @@ export default function StorageVisualizer({
 
       {proxyInfo && (
         <div className="border-b border-green-500/30 bg-green-900/10 px-4 py-2 text-[11px] text-green-500">
-          <span className="font-bold">EIP-1967 proxy detected.</span>{" "}
+          <span className="font-bold">
+            {proxyKindLabel(proxyInfo.kind)} detected.
+          </span>{" "}
           <span>Proxy storage: {truncateAddress(proxyInfo.proxyAddress)}</span>
           <span className="mx-2">|</span>
           <span>

--- a/src/lib/decode-storage-value.ts
+++ b/src/lib/decode-storage-value.ts
@@ -65,7 +65,7 @@ export async function resolveStorageValue(
       return {
         kind: "unsupported",
         display: "—",
-        note: "Mapping — pick a key to resolve a value.",
+        note: "Mapping — a value can't be read without a key, which isn't supported here.",
       };
     case "dynamic_array": {
       const length = hexToBigInt(rawSlotHex as `0x${string}`);

--- a/src/lib/decode-storage-value.ts
+++ b/src/lib/decode-storage-value.ts
@@ -1,0 +1,269 @@
+import { concatHex, getAddress, hexToBigInt, keccak256, numberToHex, pad, slice } from "viem";
+import type { TypeItem } from "@openzeppelin/upgrades-core";
+
+// Runtime type entries carry untyped solc fields (encoding, key, value,
+// base) that the OZ TypeItem interface doesn't declare - see the same
+// pattern/comment in storage-layout-export.ts.
+export type RawTypeItem = TypeItem & {
+  encoding?: "inplace" | "mapping" | "dynamic_array" | "bytes";
+  base?: string;
+  key?: string;
+  value?: string;
+};
+export type RawTypes = Record<string, RawTypeItem>;
+
+export type DecodedValueKind =
+  | "uint"
+  | "int"
+  | "bool"
+  | "address"
+  | "bytes-fixed"
+  | "string"
+  | "bytes-dynamic"
+  | "enum"
+  | "array-length"
+  | "array-element"
+  | "unsupported";
+
+export interface DecodedValue {
+  kind: DecodedValueKind;
+  /** Human-readable rendering, e.g. "42", "true", "0xabc...", "\"hello\"". */
+  display: string;
+  /** Extra context shown alongside the value, e.g. why it can't be resolved further. */
+  note?: string;
+  /** Set only for kind "array-element". */
+  index?: number;
+}
+
+type FetchExtra = (slots: string[]) => Promise<Record<string, string>>;
+
+/**
+ * Resolves one storage row's value: decodes what's decodable from the
+ * already-fetched `rawSlotHex`, and - only for long-form dynamic
+ * bytes/string data, which lives at keccak256(slot) onward rather than in
+ * the slot itself - calls `fetchExtra` for the extra slots it needs.
+ *
+ * `offsetBytes`/`widthBytes` describe the byte range *this row's own slot*
+ * contributes (Solidity's own offset convention: 0 = low-order/rightmost
+ * end). `byteRangeStart` is how many bytes of the item's *own* value were
+ * already shown by earlier rows (0 unless this is a continuation row of a
+ * multi-slot item) - it's what lets a fixed-array row figure out which
+ * element indices it's showing.
+ */
+export async function resolveStorageValue(
+  type: RawTypeItem,
+  types: RawTypes,
+  offsetBytes: number,
+  widthBytes: number,
+  byteRangeStart: number,
+  absoluteSlot: bigint,
+  rawSlotHex: string,
+  fetchExtra: FetchExtra,
+): Promise<DecodedValue | DecodedValue[]> {
+  switch (type.encoding) {
+    case "mapping":
+      return {
+        kind: "unsupported",
+        display: "—",
+        note: "Mapping — pick a key to resolve a value.",
+      };
+    case "dynamic_array": {
+      const length = hexToBigInt(rawSlotHex as `0x${string}`);
+      return {
+        kind: "array-length",
+        display: `length: ${length}`,
+        note: "Array elements are not resolved.",
+      };
+    }
+    case "bytes":
+      return resolveDynamicBytes(type, absoluteSlot, rawSlotHex, fetchExtra);
+    case "inplace":
+      if (type.label.endsWith("]")) {
+        return resolveFixedArray(
+          type,
+          types,
+          offsetBytes,
+          widthBytes,
+          byteRangeStart,
+          absoluteSlot,
+          rawSlotHex,
+          fetchExtra,
+        );
+      }
+      return decodeInplaceScalar(type, types, offsetBytes, widthBytes, rawSlotHex);
+    default:
+      return { kind: "unsupported", display: toHexPreview(rawSlotHex) };
+  }
+}
+
+async function resolveFixedArray(
+  type: RawTypeItem,
+  types: RawTypes,
+  offsetBytes: number,
+  widthBytes: number,
+  byteRangeStart: number,
+  absoluteSlot: bigint,
+  rawSlotHex: string,
+  fetchExtra: FetchExtra,
+): Promise<DecodedValue[] | DecodedValue> {
+  const elementType = type.base ? types[type.base] : undefined;
+  const elementWidth = Number(elementType?.numberOfBytes ?? 0);
+
+  // Multi-dimensional arrays, arrays of structs, or anything that doesn't
+  // cleanly divide into this row's window: not attempted, raw hex only.
+  // A struct's `members` are objects (fields); an enum's are plain strings
+  // (value names) - only the former makes the element composite.
+  const isStructElement =
+    Array.isArray(elementType?.members) &&
+    elementType.members.length > 0 &&
+    typeof elementType.members[0] !== "string";
+  const isComposite =
+    !elementType ||
+    elementWidth <= 0 ||
+    elementType.label.endsWith("]") ||
+    isStructElement;
+  if (
+    isComposite ||
+    widthBytes % elementWidth !== 0 ||
+    byteRangeStart % elementWidth !== 0
+  ) {
+    return {
+      kind: "unsupported",
+      display: toHexPreview(rawSlotHex),
+      note: "Composite value — individual elements are not resolved.",
+    };
+  }
+
+  const firstIndex = byteRangeStart / elementWidth;
+  const count = widthBytes / elementWidth;
+  const results: DecodedValue[] = [];
+  for (let p = 0; p < count; p++) {
+    const index = firstIndex + p;
+    const elementOffset = offsetBytes + p * elementWidth;
+    let decoded: DecodedValue;
+    if (elementType.encoding === "bytes") {
+      // Each element of an array of dynamic bytes/string occupies its own
+      // full slot; for a packed slot of *wide* (32-byte) elements this row
+      // holds exactly one, so its own absoluteSlot is that element's slot.
+      decoded = await resolveDynamicBytes(elementType, absoluteSlot, rawSlotHex, fetchExtra);
+    } else {
+      decoded = decodeInplaceScalar(elementType, types, elementOffset, elementWidth, rawSlotHex);
+    }
+    results.push({ ...decoded, kind: "array-element", index });
+  }
+  return results;
+}
+
+function decodeInplaceScalar(
+  type: RawTypeItem,
+  types: RawTypes,
+  offset: number,
+  width: number,
+  rawSlotHex: string,
+): DecodedValue {
+  const resolved = type.underlying ? (types[type.underlying] ?? type) : type;
+  const label = resolved.label;
+  const bytes = extractBytes(rawSlotHex, offset, width);
+
+  if (label === "bool") {
+    return { kind: "bool", display: hexToBigInt(bytes) !== 0n ? "true" : "false" };
+  }
+  if (label === "address" || label.startsWith("contract ")) {
+    return { kind: "address", display: getAddress(pad(bytes, { size: 20 })) };
+  }
+  if (label.startsWith("enum ")) {
+    const index = Number(hexToBigInt(bytes));
+    const members = resolved.members as string[] | undefined;
+    const name = members?.[index];
+    return {
+      kind: "enum",
+      display: name ? `${name} (${index})` : `unknown (${index})`,
+    };
+  }
+  if (/^bytes\d+$/.test(label)) {
+    return { kind: "bytes-fixed", display: bytes };
+  }
+  if (label.startsWith("uint")) {
+    return { kind: "uint", display: hexToBigInt(bytes).toString() };
+  }
+  if (label.startsWith("int")) {
+    return { kind: "int", display: decodeSignedInt(bytes, width).toString() };
+  }
+  return { kind: "unsupported", display: toHexPreview(rawSlotHex) };
+}
+
+async function resolveDynamicBytes(
+  type: RawTypeItem,
+  absoluteSlot: bigint,
+  rawSlotHex: string,
+  fetchExtra: FetchExtra,
+): Promise<DecodedValue> {
+  const isString = type.label === "string";
+  const kind: DecodedValueKind = isString ? "string" : "bytes-dynamic";
+  const raw = BigInt(rawSlotHex);
+  const isLongForm = (raw & 1n) === 1n;
+
+  let dataBytes: `0x${string}`;
+  if (!isLongForm) {
+    // Short form: length is in the last byte (value/2), data is the
+    // remaining bytes, left-aligned (from the high-order end) in the slot.
+    const length = (raw & 0xffn) / 2n;
+    dataBytes = slice(rawSlotHex as `0x${string}`, 0, Number(length));
+  } else {
+    const length = (raw - 1n) / 2n;
+    const slotCount = Number((length + 31n) / 32n);
+    const basePointer = hexToBigInt(keccak256(pad(numberToHex(absoluteSlot), { size: 32 })));
+    const neededSlots = Array.from({ length: slotCount }, (_, i) => (basePointer + BigInt(i)).toString());
+    const extra = await fetchExtra(neededSlots);
+    const chunks: `0x${string}`[] = [];
+    for (const key of neededSlots) {
+      const chunk = extra[key];
+      if (chunk === undefined) {
+        return {
+          kind,
+          display: toHexPreview(rawSlotHex),
+          note: "Long value — failed to fetch its data slots.",
+        };
+      }
+      chunks.push(chunk as `0x${string}`);
+    }
+    dataBytes = slice(concatHex(chunks), 0, Number(length));
+  }
+
+  if (isString) {
+    try {
+      const decoded = new TextDecoder("utf-8", { fatal: true }).decode(hexToBytes(dataBytes));
+      return { kind, display: JSON.stringify(decoded) };
+    } catch {
+      return { kind, display: dataBytes, note: "Not valid UTF-8 — showing raw bytes." };
+    }
+  }
+  return { kind, display: dataBytes };
+}
+
+function hexToBytes(hex: `0x${string}`): Uint8Array {
+  const clean = hex.slice(2);
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// Storage packs items with offset 0 at the low-order (rightmost) end of the
+// 32-byte slot; extract the `width`-byte range for an item at `offset`.
+function extractBytes(slotHex: string, offset: number, width: number): `0x${string}` {
+  const start = 32 - offset - width;
+  return slice(slotHex as `0x${string}`, start, start + width);
+}
+
+function decodeSignedInt(bytes: `0x${string}`, width: number): bigint {
+  const value = hexToBigInt(bytes);
+  const bits = BigInt(width * 8);
+  const signBit = 1n << (bits - 1n);
+  return value & signBit ? value - (1n << bits) : value;
+}
+
+function toHexPreview(hex: string): string {
+  return hex.length > 20 ? `${hex.slice(0, 18)}…` : hex;
+}

--- a/src/lib/eip1967.ts
+++ b/src/lib/eip1967.ts
@@ -1,5 +1,7 @@
 export interface Eip1967ProxyInfo {
-  kind: "eip1967" | "beacon";
+  // "legacy" = implementation found via the pre-EIP-1967 ZeppelinOS slot
+  // (keccak256("org.zeppelinos.proxy.implementation")), e.g. USDC.
+  kind: "eip1967" | "beacon" | "legacy";
   proxyAddress: string;
   implementationAddress: string;
   adminAddress?: string;
@@ -10,4 +12,15 @@ export interface Eip1967ProxyInfoResponse {
   isProxy: boolean;
   proxyInfo?: Eip1967ProxyInfo;
   message?: string;
+}
+
+export function proxyKindLabel(kind: Eip1967ProxyInfo["kind"]): string {
+  switch (kind) {
+    case "beacon":
+      return "EIP-1967 beacon proxy";
+    case "legacy":
+      return "Legacy upgradeable proxy (pre-EIP-1967 slots)";
+    default:
+      return "EIP-1967 proxy";
+  }
 }

--- a/src/lib/eip1967.ts
+++ b/src/lib/eip1967.ts
@@ -1,0 +1,13 @@
+export interface Eip1967ProxyInfo {
+  kind: "eip1967" | "beacon";
+  proxyAddress: string;
+  implementationAddress: string;
+  adminAddress?: string;
+  beaconAddress?: string;
+}
+
+export interface Eip1967ProxyInfoResponse {
+  isProxy: boolean;
+  proxyInfo?: Eip1967ProxyInfo;
+  message?: string;
+}

--- a/src/lib/storage-layout-export.ts
+++ b/src/lib/storage-layout-export.ts
@@ -1,6 +1,7 @@
 import type { StorageLayout, StorageItem } from "@openzeppelin/upgrades-core";
 import { deriveNamespaceBaseSlot } from "@/lib/erc7201";
 import { normalizeUint256Literal } from "@/lib/integer-literals";
+import type { Eip1967ProxyInfo } from "@/lib/eip1967";
 
 const EXPORT_SCHEMA_VERSION = "evm-storage.codes/storage-layout-export@1";
 const JSON_INDENT_SPACES = 2;
@@ -14,6 +15,8 @@ export type LayoutEntry = {
   contractName: string;
   chainId: number | undefined;
   address: string | undefined;
+  sourceAddress?: string;
+  proxyInfo?: Eip1967ProxyInfo;
   storageLayout: StorageLayout;
 };
 
@@ -117,7 +120,14 @@ function buildWrapper(
   mode: "full" | "tab",
   namespace?: string,
 ): Record<string, unknown> {
-  const { contractName, chainId, address, storageLayout } = entry;
+  const {
+    contractName,
+    chainId,
+    address,
+    sourceAddress,
+    proxyInfo,
+    storageLayout,
+  } = entry;
   const allTypes = (storageLayout.types ?? {}) as RawTypes;
 
   if (mode === "full") {
@@ -150,6 +160,8 @@ function buildWrapper(
       contractName,
       chainId,
       address,
+      sourceAddress,
+      proxyInfo,
       solcVersion: storageLayout.solcVersion,
       layoutVersion: storageLayout.layoutVersion,
       baseSlot: normalizedRootBaseSlot(storageLayout),
@@ -182,6 +194,8 @@ function buildWrapper(
     contractName,
     chainId,
     address,
+    sourceAddress,
+    proxyInfo,
     solcVersion: storageLayout.solcVersion,
     layoutVersion: storageLayout.layoutVersion,
     namespace,

--- a/src/lib/storage-values.ts
+++ b/src/lib/storage-values.ts
@@ -1,0 +1,23 @@
+// Fetches raw 32-byte storage slot values for a contract from the chain.
+// Slots are passed through as opaque decimal/hex strings and echoed back as
+// keys, so callers can pass either plain slot indices or keccak256-derived
+// pointers (used to resolve long-form dynamic bytes/string data).
+export async function fetchStorageValues(
+  chainId: number,
+  address: string,
+  slots: string[],
+): Promise<Record<string, string>> {
+  if (slots.length === 0) return {};
+
+  const response = await fetch("/api/get_storage_values", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chainId, address, slots }),
+  });
+
+  const json = await response.json();
+  if (!response.ok) {
+    throw new Error(json.message ?? "Failed to fetch storage values.");
+  }
+  return json.values as Record<string, string>;
+}


### PR DESCRIPTION
## Stacked PR

This PR is stacked on #119 (`feat/onchain-storage-values`), which is itself stacked on #118 (`feat/eip1967-support`). Neither is merged yet, so this diff includes all three branches' commits until they land — the only change specific to this PR is in `src/components/AnalyzeWizardButton.tsx`. Should be reviewed/merged last, after #118 and #119.

## Summary

Fixes #120: `AnalyzeWizardButton.tsx`'s address `<input>` started as an uncontrolled input (`useState<string | undefined>(initialAddress)`, defaulting to `undefined` when no `initialAddress` is provided) and became controlled the moment the user typed a character, triggering React's "A component is changing an uncontrolled input to be controlled" warning.

- `address` state now initializes to `initialAddress ?? ""` instead of `initialAddress` (typed as `string`, not `string | undefined`).
- `resetWizardState()`'s `setAddress(undefined)` updated to `setAddress("")` to match.
- `sourceAddress` is untouched — it's separate state not bound to any input, so it wasn't part of the bug.

All existing `address`-related checks (`!address`, `disabled={!chainName || !address}`, etc.) are unaffected since `""` and `undefined` are both falsy.

## Verification

- `yarn build` and `yarn lint` clean.
- Playwright: opened the Analyze wizard, typed a full address into the field character-by-character (the exact repro from the issue), and confirmed no "uncontrolled/controlled" console warning fires. Two unrelated pre-existing warnings (`DialogContent` missing `aria-describedby`) still show, confirming the check is meaningfully differentiating this fix from noise.